### PR TITLE
[Tests] Cleanup

### DIFF
--- a/Tests/FluxCollectionViewModelTests.swift
+++ b/Tests/FluxCollectionViewModelTests.swift
@@ -25,7 +25,7 @@ final class FluxCollectionViewModelTests: XCTestCase {
     func testDoubleBlankSupplementaryViewModelInitalizer() {
         parameterize(cases: (nil as CGFloat?, nil as CGFloat?), (42, nil), (nil, 43), (42, 43)) {
             let sectionModel = FluxCollectionViewModel.SectionModel(
-                cellViewModels: [generateRandomTestCollectionCellViewModel()],
+                cellViewModels: [generateTestCollectionCellViewModel()],
                 headerHeight: $0,
                 footerHeight: $1)
 
@@ -40,7 +40,7 @@ final class FluxCollectionViewModelTests: XCTestCase {
     func testBlankSupplementaryHeaderViewModelInitalizer() {
         parameterize(cases: (nil as CGFloat?, nil as CGFloat?), (42, nil), (nil, 43), (42, 43)) {
             let sectionModel = FluxCollectionViewModel.SectionModel(
-                cellViewModels: [generateRandomTestCollectionCellViewModel()],
+                cellViewModels: [generateTestCollectionCellViewModel()],
                 headerHeight: $0,
                 footerViewModel: TestCollectionViewSupplementaryViewModel(height: $1, viewKind: .footer, sectionLabel: "A"))
 
@@ -60,7 +60,7 @@ final class FluxCollectionViewModelTests: XCTestCase {
     func testBlankSupplementaryFooterViewModelInitalizer() {
         parameterize(cases: (nil as CGFloat?, nil as CGFloat?), (42, nil), (nil, 43), (42, 43)) {
             let sectionModel = FluxCollectionViewModel.SectionModel(
-                cellViewModels: [generateRandomTestCollectionCellViewModel()],
+                cellViewModels: [generateTestCollectionCellViewModel()],
                 headerViewModel: TestCollectionViewSupplementaryViewModel(height: $0, viewKind: .header, sectionLabel: "A"),
                 footerHeight: $1)
 
@@ -80,7 +80,7 @@ final class FluxCollectionViewModelTests: XCTestCase {
     func testDoubleCustomSupplementaryViewModelInitalizer() {
         parameterize(cases: (nil as CGFloat?, nil as CGFloat?), (42, nil), (nil, 43), (42, 43)) {
             let sectionModel = FluxCollectionViewModel.SectionModel(
-                cellViewModels: [generateRandomTestCollectionCellViewModel()],
+                cellViewModels: [generateTestCollectionCellViewModel()],
                 headerViewModel: TestCollectionViewSupplementaryViewModel(height: $0, viewKind: .header, sectionLabel: "A"),
                 footerViewModel: TestCollectionViewSupplementaryViewModel(height: $1, viewKind: .footer, sectionLabel: "A"))
 
@@ -109,9 +109,9 @@ final class FluxCollectionViewModelTests: XCTestCase {
                 footerHeight: nil),
             FluxCollectionViewModel.SectionModel(
                 cellViewModels: [
-                    generateRandomTestCollectionCellViewModel("A"),
-                    generateRandomTestCollectionCellViewModel("B"),
-                    generateRandomTestCollectionCellViewModel("C"),
+                    generateTestCollectionCellViewModel("A"),
+                    generateTestCollectionCellViewModel("B"),
+                    generateTestCollectionCellViewModel("C"),
                 ],
                 headerHeight: 43,
                 footerHeight: nil),

--- a/Tests/FluxTableViewModelTests.swift
+++ b/Tests/FluxTableViewModelTests.swift
@@ -24,9 +24,10 @@ final class FluxTableViewModelTests: XCTestCase {
         let sectionModel = FluxTableViewModel.SectionModel(
             headerTitle: "foo",
             headerHeight: 42,
-            cellViewModels: [generateRandomTestCellViewModel()],
+            cellViewModels: [generateTestCellViewModel()],
             footerTitle: "bar",
-            footerHeight: 43)
+            footerHeight: 43
+        )
 
         self.runCommonSectionModelAttributeTests(sectionModel)
 
@@ -38,10 +39,12 @@ final class FluxTableViewModelTests: XCTestCase {
     }
 
     func testCustomHeaderFooterSectionModelInitalizer() {
-        let sectionModel = FluxTableViewModel.SectionModel(cellViewModels: [generateRandomTestCellViewModel()],
-                                                           headerViewModel: TestHeaderFooterViewModel(height: 42, viewKind: .header, label: "A"),
-                                                           footerViewModel: TestHeaderFooterViewModel(height: 43, viewKind: .footer, label: "A"),
-                                                           collapsed: true)
+        let sectionModel = FluxTableViewModel.SectionModel(
+            cellViewModels: [generateTestCellViewModel()],
+            headerViewModel: TestHeaderFooterViewModel(height: 42, viewKind: .header, label: "A"),
+            footerViewModel: TestHeaderFooterViewModel(height: 43, viewKind: .footer, label: "A"),
+            collapsed: true
+        )
 
         self.runCommonSectionModelAttributeTests(sectionModel)
 
@@ -60,6 +63,10 @@ final class FluxTableViewModelTests: XCTestCase {
         XCTAssertEqual(footerInfo?.accessibilityFormat.accessibilityIdentifierForSection(44), "access_footer+44")
     }
 
+
+    /// The table view model allows subscripting into sections and cells.
+    /// If the section or cell at the index does not exist, the table view
+    /// model returns `nil`.
     func testSubscripts() {
         let tableViewModel = FluxTableViewModel(sectionModels: [
             FluxTableViewModel.SectionModel(
@@ -70,19 +77,37 @@ final class FluxTableViewModelTests: XCTestCase {
                 headerTitle: "section_2",
                 headerHeight: 43,
                 cellViewModels: [
-                    generateRandomTestCellViewModel("A"),
-                    generateRandomTestCellViewModel("B"),
-                    generateRandomTestCellViewModel("C"),
+                    generateTestCellViewModel("A"),
+                    generateTestCellViewModel("B"),
+                    generateTestCellViewModel("C"),
             ]),
         ])
 
+        // Returns `nil` when there's no cell/section at the provided path.
         XCTAssertNil(tableViewModel[9]?.headerViewModel?.title)
-        XCTAssertEqual(tableViewModel[0]?.headerViewModel?.title, "section_1")
+        XCTAssertNil(tableViewModel[IndexPath(row: 0, section: 0)])
+        XCTAssertNil(tableViewModel[IndexPath(row: 0, section: 9)])
+        XCTAssertNil(tableViewModel[IndexPath(row: 9, section: 1)])
 
-        XCTAssertNil(tableViewModel[path(0, 0)])
-        XCTAssertNil(tableViewModel[path(9, 0)])
-        XCTAssertNil(tableViewModel[path(1, 9)])
-        XCTAssertEqual((tableViewModel[path(1, 0)] as? TestCellViewModel)?.label, "A")
+        // Returns the section/cell model, if the index path exists within the table view model.
+        XCTAssertEqual(tableViewModel[0]?.headerViewModel?.title, "section_1")
+        XCTAssertEqual((tableViewModel[IndexPath(row: 0, section: 1)] as? TestCellViewModel)?.label, "A")
+    }
+
+    /// The `.isEmpty` property of the table view returns `true` when the table view
+    /// contains no sections or one section with no cells.
+    func testIsEmpty() {
+        let tableViewModel1 = FluxTableViewModel(sectionModels: [])
+        XCTAssertTrue(tableViewModel1.isEmpty)
+
+        let tableViewModel2 = FluxTableViewModel(
+            sectionModels: [FluxTableViewModel.SectionModel(
+                cellViewModels: []
+            )]
+        )
+
+        XCTAssertTrue(tableViewModel1.isEmpty)
+        XCTAssertTrue(tableViewModel2.isEmpty)
     }
 
     func runCommonSectionModelAttributeTests(_ sectionModel: FluxTableViewModel.SectionModel) {

--- a/Tests/TestFluxCollectionViewModels.swift
+++ b/Tests/TestFluxCollectionViewModels.swift
@@ -89,7 +89,7 @@ class TestFluxCollectionReusableView: UICollectionReusableView {
     }
 }
 
-func generateRandomTestCollectionCellViewModel(_ label: String? = nil) -> TestCollectionCellViewModel {
+func generateTestCollectionCellViewModel(_ label: String? = nil) -> TestCollectionCellViewModel {
     return TestCollectionCellViewModel(
         label: label ?? UUID().uuidString,
         didSelectClosure: nil,

--- a/Tests/TestFluxTableViewModels.swift
+++ b/Tests/TestFluxTableViewModels.swift
@@ -70,7 +70,7 @@ func path(_ section: Int, _ row: Int = 0) -> IndexPath {
     return IndexPath(row: row, section: section)
 }
 
-func generateRandomTestCellViewModel(_ label: String? = nil) -> TestCellViewModel {
+func generateTestCellViewModel(_ label: String? = nil) -> TestCellViewModel {
     return TestCellViewModel(label: label ?? UUID().uuidString,
                              willBeginEditing: nil,
                              didEndEditing: nil,


### PR DESCRIPTION
First iteration of cleanups up for review:
- Eliminate the word “random” from generated test data
- Eliminate helper functions that obfuscate underlying types (`path()` instead of `IndexPath()` - needs to be fixed in more places)
- Add docs to tests that describe their intent
- If tests contain multiple assertions (which we’ll often avoid) order them in a logical way