### PR TITLE
[Test] Cleanup Mock Usage

### DIFF
--- a/ReactiveLists.xcodeproj/project.pbxproj
+++ b/ReactiveLists.xcodeproj/project.pbxproj
@@ -18,7 +18,7 @@
 		257664231F2907FE00C037E3 /* TableViewCells.swift in Sources */ = {isa = PBXBuildFile; fileRef = 257664221F2907FE00C037E3 /* TableViewCells.swift */; };
 		257A97C02017A5D300164403 /* TestCollectionViewModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 257A97BC2017A5AA00164403 /* TestCollectionViewModels.swift */; };
 		257A97C12017A5D300164403 /* TestTableViewModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 257A97BD2017A5AA00164403 /* TestTableViewModels.swift */; };
-		257A97D42017A82900164403 /* TableViewDataSourceMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 257A97C42017A80B00164403 /* TableViewDataSourceMocks.swift */; };
+		257A97D42017A82900164403 /* TableViewMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 257A97C42017A80B00164403 /* TableViewMocks.swift */; };
 		257A97D52017A82900164403 /* TableViewDataSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 257A97C52017A80B00164403 /* TableViewDataSourceTests.swift */; };
 		257A97D62017A82900164403 /* TableViewDiffingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 257A97C62017A80B00164403 /* TableViewDiffingTests.swift */; };
 		257A97D72017A82900164403 /* TableViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 257A97C72017A80B00164403 /* TableViewModelTests.swift */; };
@@ -85,7 +85,7 @@
 		257664221F2907FE00C037E3 /* TableViewCells.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TableViewCells.swift; sourceTree = "<group>"; };
 		257A97BC2017A5AA00164403 /* TestCollectionViewModels.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestCollectionViewModels.swift; sourceTree = "<group>"; };
 		257A97BD2017A5AA00164403 /* TestTableViewModels.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestTableViewModels.swift; sourceTree = "<group>"; };
-		257A97C42017A80B00164403 /* TableViewDataSourceMocks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TableViewDataSourceMocks.swift; sourceTree = "<group>"; };
+		257A97C42017A80B00164403 /* TableViewMocks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TableViewMocks.swift; sourceTree = "<group>"; };
 		257A97C52017A80B00164403 /* TableViewDataSourceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TableViewDataSourceTests.swift; sourceTree = "<group>"; };
 		257A97C62017A80B00164403 /* TableViewDiffingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TableViewDiffingTests.swift; sourceTree = "<group>"; };
 		257A97C72017A80B00164403 /* TableViewModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TableViewModelTests.swift; sourceTree = "<group>"; };
@@ -190,7 +190,7 @@
 		257A97C32017A80B00164403 /* TableView */ = {
 			isa = PBXGroup;
 			children = (
-				257A97C42017A80B00164403 /* TableViewDataSourceMocks.swift */,
+				257A97C42017A80B00164403 /* TableViewMocks.swift */,
 				257A97C52017A80B00164403 /* TableViewDataSourceTests.swift */,
 				257A97C62017A80B00164403 /* TableViewDiffingTests.swift */,
 				257A97C72017A80B00164403 /* TableViewModelTests.swift */,
@@ -634,7 +634,7 @@
 				257A97C02017A5D300164403 /* TestCollectionViewModels.swift in Sources */,
 				257A97D92017A82F00164403 /* CollectionViewModelTests.swift in Sources */,
 				257A97DA2017A83400164403 /* XCTest+Parameterized.swift in Sources */,
-				257A97D42017A82900164403 /* TableViewDataSourceMocks.swift in Sources */,
+				257A97D42017A82900164403 /* TableViewMocks.swift in Sources */,
 				257A97DD2017AA9000164403 /* CollectionViewDataSourceMocks.swift in Sources */,
 				257A97D52017A82900164403 /* TableViewDataSourceTests.swift in Sources */,
 				257A97C12017A5D300164403 /* TestTableViewModels.swift in Sources */,

--- a/ReactiveLists.xcodeproj/project.pbxproj
+++ b/ReactiveLists.xcodeproj/project.pbxproj
@@ -18,13 +18,14 @@
 		257664231F2907FE00C037E3 /* TableViewCells.swift in Sources */ = {isa = PBXBuildFile; fileRef = 257664221F2907FE00C037E3 /* TableViewCells.swift */; };
 		257A97C02017A5D300164403 /* TestCollectionViewModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 257A97BC2017A5AA00164403 /* TestCollectionViewModels.swift */; };
 		257A97C12017A5D300164403 /* TestTableViewModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 257A97BD2017A5AA00164403 /* TestTableViewModels.swift */; };
-		257A97D42017A82900164403 /* SharedTableViewDataSourceMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 257A97C42017A80B00164403 /* SharedTableViewDataSourceMocks.swift */; };
+		257A97D42017A82900164403 /* TableViewDataSourceMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 257A97C42017A80B00164403 /* TableViewDataSourceMocks.swift */; };
 		257A97D52017A82900164403 /* TableViewDataSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 257A97C52017A80B00164403 /* TableViewDataSourceTests.swift */; };
 		257A97D62017A82900164403 /* TableViewDiffingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 257A97C62017A80B00164403 /* TableViewDiffingTests.swift */; };
 		257A97D72017A82900164403 /* TableViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 257A97C72017A80B00164403 /* TableViewModelTests.swift */; };
 		257A97D82017A82F00164403 /* CollectionViewDataSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 257A97C92017A80B00164403 /* CollectionViewDataSourceTests.swift */; };
 		257A97D92017A82F00164403 /* CollectionViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 257A97CA2017A80B00164403 /* CollectionViewModelTests.swift */; };
 		257A97DA2017A83400164403 /* XCTest+Parameterized.swift in Sources */ = {isa = PBXBuildFile; fileRef = 257A97CC2017A80B00164403 /* XCTest+Parameterized.swift */; };
+		257A97DD2017AA9000164403 /* CollectionViewDataSourceMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 257A97DB2017AA3500164403 /* CollectionViewDataSourceMocks.swift */; };
 		258E31991F0D8CBC00D6F324 /* ReactiveLists.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 258E318F1F0D8CBC00D6F324 /* ReactiveLists.framework */; };
 		258E31A01F0D8CBC00D6F324 /* ReactiveLists.h in Headers */ = {isa = PBXBuildFile; fileRef = 258E31921F0D8CBC00D6F324 /* ReactiveLists.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		258E31B11F0D8D9C00D6F324 /* CollectionViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 258E31AC1F0D8D9C00D6F324 /* CollectionViewDataSource.swift */; };
@@ -84,13 +85,14 @@
 		257664221F2907FE00C037E3 /* TableViewCells.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TableViewCells.swift; sourceTree = "<group>"; };
 		257A97BC2017A5AA00164403 /* TestCollectionViewModels.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestCollectionViewModels.swift; sourceTree = "<group>"; };
 		257A97BD2017A5AA00164403 /* TestTableViewModels.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestTableViewModels.swift; sourceTree = "<group>"; };
-		257A97C42017A80B00164403 /* SharedTableViewDataSourceMocks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SharedTableViewDataSourceMocks.swift; sourceTree = "<group>"; };
+		257A97C42017A80B00164403 /* TableViewDataSourceMocks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TableViewDataSourceMocks.swift; sourceTree = "<group>"; };
 		257A97C52017A80B00164403 /* TableViewDataSourceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TableViewDataSourceTests.swift; sourceTree = "<group>"; };
 		257A97C62017A80B00164403 /* TableViewDiffingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TableViewDiffingTests.swift; sourceTree = "<group>"; };
 		257A97C72017A80B00164403 /* TableViewModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TableViewModelTests.swift; sourceTree = "<group>"; };
 		257A97C92017A80B00164403 /* CollectionViewDataSourceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CollectionViewDataSourceTests.swift; sourceTree = "<group>"; };
 		257A97CA2017A80B00164403 /* CollectionViewModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CollectionViewModelTests.swift; sourceTree = "<group>"; };
 		257A97CC2017A80B00164403 /* XCTest+Parameterized.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "XCTest+Parameterized.swift"; sourceTree = "<group>"; };
+		257A97DB2017AA3500164403 /* CollectionViewDataSourceMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionViewDataSourceMocks.swift; sourceTree = "<group>"; };
 		258E318F1F0D8CBC00D6F324 /* ReactiveLists.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ReactiveLists.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		258E31921F0D8CBC00D6F324 /* ReactiveLists.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ReactiveLists.h; sourceTree = "<group>"; };
 		258E31931F0D8CBC00D6F324 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -188,7 +190,7 @@
 		257A97C32017A80B00164403 /* TableView */ = {
 			isa = PBXGroup;
 			children = (
-				257A97C42017A80B00164403 /* SharedTableViewDataSourceMocks.swift */,
+				257A97C42017A80B00164403 /* TableViewDataSourceMocks.swift */,
 				257A97C52017A80B00164403 /* TableViewDataSourceTests.swift */,
 				257A97C62017A80B00164403 /* TableViewDiffingTests.swift */,
 				257A97C72017A80B00164403 /* TableViewModelTests.swift */,
@@ -201,6 +203,7 @@
 			children = (
 				257A97C92017A80B00164403 /* CollectionViewDataSourceTests.swift */,
 				257A97CA2017A80B00164403 /* CollectionViewModelTests.swift */,
+				257A97DB2017AA3500164403 /* CollectionViewDataSourceMocks.swift */,
 			);
 			path = CollectionView;
 			sourceTree = "<group>";
@@ -631,7 +634,8 @@
 				257A97C02017A5D300164403 /* TestCollectionViewModels.swift in Sources */,
 				257A97D92017A82F00164403 /* CollectionViewModelTests.swift in Sources */,
 				257A97DA2017A83400164403 /* XCTest+Parameterized.swift in Sources */,
-				257A97D42017A82900164403 /* SharedTableViewDataSourceMocks.swift in Sources */,
+				257A97D42017A82900164403 /* TableViewDataSourceMocks.swift in Sources */,
+				257A97DD2017AA9000164403 /* CollectionViewDataSourceMocks.swift in Sources */,
 				257A97D52017A82900164403 /* TableViewDataSourceTests.swift in Sources */,
 				257A97C12017A5D300164403 /* TestTableViewModels.swift in Sources */,
 			);

--- a/Tests/CollectionView/CollectionViewDataSourceMocks.swift
+++ b/Tests/CollectionView/CollectionViewDataSourceMocks.swift
@@ -1,0 +1,45 @@
+//
+//  PlanGrid
+//  https://www.plangrid.com
+//  https://medium.com/plangrid-technology
+//
+//  Documentation
+//  https://plangrid.github.io/ReactiveLists
+//
+//  GitHub
+//  https://github.com/plangrid/ReactiveLists
+//
+//  License
+//  Copyright © 2018-present PlanGrid, Inc.
+//  Released under an MIT license: https://opensource.org/licenses/MIT
+//
+
+import UIKit
+@testable import ReactiveLists
+
+typealias _RegisterClassCallInfo = (viewClass: AnyClass?, viewKind: SupplementaryViewKind?, reuseIdentifier: String)
+class TestCollectionView: UICollectionView {
+
+    var callsToRegisterClass: [_RegisterClassCallInfo?] = []
+    var callsToDeselect: Int = 0
+
+    override func dequeueReusableCell(withReuseIdentifier identifier: String, for indexPath: IndexPath) -> UICollectionViewCell {
+        return TestCollectionViewCell(identifier: identifier)
+    }
+
+    override func dequeueReusableSupplementaryView(ofKind elementKind: String, withReuseIdentifier identifier: String, for indexPath: IndexPath) -> UICollectionReusableView {
+        return TestCollectionReusableView(identifier: identifier)
+    }
+
+    override func register(_ viewClass: AnyClass?, forSupplementaryViewOfKind elementKind: String, withReuseIdentifier identifier: String) {
+        if let viewClass = viewClass {
+            self.callsToRegisterClass.append((viewClass, SupplementaryViewKind(collectionElementKindString: elementKind), identifier))
+        } else {
+            self.callsToRegisterClass.append(nil)
+        }
+    }
+
+    override func deselectItem(at indexPath: IndexPath, animated: Bool) {
+        self.callsToDeselect += 1
+    }
+}

--- a/Tests/CollectionView/CollectionViewDataSourceTests.swift
+++ b/Tests/CollectionView/CollectionViewDataSourceTests.swift
@@ -23,7 +23,7 @@ final class CollectionViewDataSourceTests: XCTestCase {
 
     private var _collectionView: TestCollectionView!
     private var _collectionViewModel: CollectionViewModel!
-    private var _collectionViewDataSource: TestCollectionViewDataSource!
+    private var _collectionViewDataSource: CollectionViewDataSource!
 
     private var _lastSelectClosureCaller: String?
     private var _lastDeselectClosureCaller: String?
@@ -49,7 +49,7 @@ final class CollectionViewDataSourceTests: XCTestCase {
                 headerViewModel: TestCollectionViewSupplementaryViewModel(height: nil, viewKind: .header, sectionLabel: "D"),
                 footerViewModel: TestCollectionViewSupplementaryViewModel(height: nil, viewKind: .footer, sectionLabel: "D")),
         ])
-        self._collectionViewDataSource = TestCollectionViewDataSource()
+        self._collectionViewDataSource = CollectionViewDataSource()
         self._collectionViewDataSource.collectionViewModel.value = self._collectionViewModel
     }
 
@@ -58,11 +58,7 @@ final class CollectionViewDataSourceTests: XCTestCase {
         XCTAssertNil(self._collectionView.delegate)
         XCTAssertNil(self._collectionView.dataSource)
 
-        self._collectionViewDataSource.label = "baz"
         self._collectionViewDataSource.collectionView = self._collectionView
-
-        XCTAssertEqual((self._collectionView.delegate as? TestCollectionViewDataSource)?.label, "baz")
-        XCTAssertEqual((self._collectionView.dataSource as? TestCollectionViewDataSource)?.label, "baz")
 
         // Test that header and footer view classes explicitly provided in the view model are registered
         let registerCalls = self._collectionView.callsToRegisterClass
@@ -219,7 +215,7 @@ final class CollectionViewDataSourceTests: XCTestCase {
 
     func testShouldDeselectUponSelection() {
         // Default is to deselect upong selection
-        let dataSource = TestCollectionViewDataSource()
+        let dataSource = CollectionViewDataSource()
         let collectionView = TestCollectionView(frame: CGRect.zero, collectionViewLayout: UICollectionViewLayout())
         dataSource.collectionView = collectionView
         XCTAssertEqual(collectionView.callsToDeselect, 0)
@@ -228,7 +224,7 @@ final class CollectionViewDataSourceTests: XCTestCase {
     }
 
     func testShouldNotDeselectUponSelection() {
-        let dataSource = TestCollectionViewDataSource(shouldDeselectUponSelection: false)
+        let dataSource = CollectionViewDataSource(shouldDeselectUponSelection: false)
         let collectionView = TestCollectionView(frame: CGRect.zero, collectionViewLayout: UICollectionViewLayout())
         dataSource.collectionView = collectionView
         XCTAssertEqual(collectionView.callsToDeselect, 0)
@@ -292,35 +288,4 @@ final class CollectionViewDataSourceTests: XCTestCase {
         XCTAssertEqual(info?.viewKind, kind)
         XCTAssertEqual(info?.reuseIdentifier, identifier)
     }
-}
-
-private typealias _RegisterClassCallInfo = (viewClass: AnyClass?, viewKind: SupplementaryViewKind?, reuseIdentifier: String)
-private class TestCollectionView: UICollectionView {
-
-    var callsToRegisterClass: [_RegisterClassCallInfo?] = []
-    var callsToDeselect: Int = 0
-
-    override func dequeueReusableCell(withReuseIdentifier identifier: String, for indexPath: IndexPath) -> UICollectionViewCell {
-        return TestCollectionViewCell(identifier: identifier)
-    }
-
-    override func dequeueReusableSupplementaryView(ofKind elementKind: String, withReuseIdentifier identifier: String, for indexPath: IndexPath) -> UICollectionReusableView {
-        return TestCollectionReusableView(identifier: identifier)
-    }
-
-    override func register(_ viewClass: AnyClass?, forSupplementaryViewOfKind elementKind: String, withReuseIdentifier identifier: String) {
-        if let viewClass = viewClass {
-            self.callsToRegisterClass.append((viewClass, SupplementaryViewKind(collectionElementKindString: elementKind), identifier))
-        } else {
-            self.callsToRegisterClass.append(nil)
-        }
-    }
-
-    override func deselectItem(at indexPath: IndexPath, animated: Bool) {
-        self.callsToDeselect += 1
-    }
-}
-
-private class TestCollectionViewDataSource: CollectionViewDataSource {
-    var label: String?
 }

--- a/Tests/Fixtures/TestTableViewModels.swift
+++ b/Tests/Fixtures/TestTableViewModels.swift
@@ -26,17 +26,18 @@ struct TestCellViewModel: TableViewCellViewModel {
 
     let cellIdentifier: String
     let label: String
-    let willBeginEditing: WillBeginEditingClosure?
-    let didEndEditing: DidEndEditingClosure?
-    let commitEditingStyle: CommitEditingStyleClosure?
-    let didSelectClosure: DidSelectClosure?
+    var willBeginEditing: WillBeginEditingClosure?
+    var didEndEditing: DidEndEditingClosure?
+    var commitEditingStyle: CommitEditingStyleClosure?
+    var didSelectClosure: DidSelectClosure?
 
     init(label: String,
          cellIdentifier: String? = nil,
          willBeginEditing: WillBeginEditingClosure? = nil,
          didEndEditing: DidEndEditingClosure? = nil,
          commitEditingStyle: CommitEditingStyleClosure? = nil,
-         didSelectClosure: DidSelectClosure? = nil) {
+         didSelectClosure: DidSelectClosure? = nil
+    ) {
         self.cellIdentifier = cellIdentifier ?? label
         self.label = label
         self.willBeginEditing = willBeginEditing

--- a/Tests/TableView/TableViewDataSourceMocks.swift
+++ b/Tests/TableView/TableViewDataSourceMocks.swift
@@ -62,10 +62,6 @@ class TestTableView: UITableView {
     }
 }
 
-class TestTableViewDataSource: TableViewDataSource {
-    var label: String?
-}
-
 extension TableViewDataSource {
     func _getCell(_ path: IndexPath) -> TestTableViewCell? {
         let tableView = self._tableView

--- a/Tests/TableView/TableViewDataSourceTests.swift
+++ b/Tests/TableView/TableViewDataSourceTests.swift
@@ -22,7 +22,7 @@ final class TableViewDataSourceTests: XCTestCase {
 
     private var _tableView: TestTableView!
     private var _tableViewModel: TableViewModel!
-    private var _tableViewDataSource: TestTableViewDataSource!
+    private var _tableViewDataSource: TableViewDataSource!
 
     private var _lastBeginEditingClosureCaller: String?
     private var _lastEndEditingClosureCaller: String?
@@ -53,7 +53,7 @@ final class TableViewDataSourceTests: XCTestCase {
                 footerViewModel: nil,
                 collapsed: true),
             ], sectionIndexTitles: ["A", "Z", "Z"])
-        self._tableViewDataSource = TestTableViewDataSource(tableView: tableView)
+        self._tableViewDataSource = TableViewDataSource(tableView: tableView)
         self._tableViewDataSource.tableViewModel.value = self._tableViewModel
     }
 
@@ -61,11 +61,6 @@ final class TableViewDataSourceTests: XCTestCase {
         // Unset the table view from `setUp` and use a different table view for this test
         let tableView = TestTableView()
         self.setupWithTableView(tableView)
-
-        self._tableViewDataSource.label = "baz"
-
-        XCTAssertEqual((tableView.delegate as? TestTableViewDataSource)?.label, "baz")
-        XCTAssertEqual((tableView.dataSource as? TestTableViewDataSource)?.label, "baz")
 
         XCTAssertEqual(tableView.callsToRegisterClass.count, 2)
         XCTAssertEqual(tableView.callsToRegisterClass[0].identifier, "reuse_header+A")
@@ -239,7 +234,7 @@ final class TableViewDataSourceTests: XCTestCase {
 
     func testShouldDeselectUponSelection() {
         let tableView = TestTableView()
-        let dataSource = TestTableViewDataSource(tableView: tableView)
+        let dataSource = TableViewDataSource(tableView: tableView)
         XCTAssertEqual(tableView.callsToDeselect, 0)
         dataSource.tableView(tableView, didSelectRowAt: path(0))
         XCTAssertEqual(tableView.callsToDeselect, 1)
@@ -247,7 +242,7 @@ final class TableViewDataSourceTests: XCTestCase {
 
     func testShouldNotDeselectUponSelection() {
         let tableView = TestTableView()
-        let dataSource = TestTableViewDataSource(
+        let dataSource = TableViewDataSource(
             tableView: tableView,
             shouldDeselectUponSelection: false
         )

--- a/Tests/TableView/TableViewMocks.swift
+++ b/Tests/TableView/TableViewMocks.swift
@@ -81,3 +81,25 @@ extension TableViewDataSource {
         return cell
     }
 }
+
+class MockCellViewModel: TableViewCellViewModel {
+    var accessibilityFormat: CellAccessibilityFormat = "_"
+    var cellIdentifier = "_"
+    func applyViewModelToCell(_ cell: UITableViewCell) -> UITableViewCell { return cell }
+
+    var didSelectClosure: DidSelectClosure?
+    var didSelectCalled = false
+    var willBeginEditing: WillBeginEditingClosure?
+    var willBeginEditingCalled = false
+    var didEndEditing: DidEndEditingClosure?
+    var didEndEditingCalled = false
+    var commitEditingStyle: CommitEditingStyleClosure?
+    var commitEditingStyleCalled: UITableViewCellEditingStyle?
+
+    init() {
+        self.didSelectClosure = { [unowned self] in self.didSelectCalled = true }
+        self.willBeginEditing = { [unowned self] in self.willBeginEditingCalled = true }
+        self.didEndEditing = { [unowned self] in self.didEndEditingCalled = true }
+        self.commitEditingStyle = { [unowned self] in self.commitEditingStyleCalled = $0 }
+    }
+}


### PR DESCRIPTION
## Changes in this pull request

- Colocates mocks and stubs for different tests
- Rewrites table view test that tests that cells receive correct callbacks (now uses dedicated mocks instead of global state)

This PR is dependent on #33 