### PR TITLE
[Refactor] Make Sections on Models Non-Optional

### DIFF
--- a/Sources/CollectionViewDataSource.swift
+++ b/Sources/CollectionViewDataSource.swift
@@ -50,7 +50,7 @@ public class CollectionViewDataSource: NSObject, UICollectionViewDataSource, UIC
     }
 
     public func numberOfSections(in collectionView: UICollectionView) -> Int {
-        return self._collectionViewModel?.sectionModels?.count ?? 0
+        return self._collectionViewModel?.sectionModels.count ?? 0
     }
 
     public func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
@@ -169,7 +169,7 @@ public class CollectionViewDataSource: NSObject, UICollectionViewDataSource, UIC
 
     private func _registerSupplementaryViews() {
         guard let collectionView = self.collectionView else { return }
-        self._collectionViewModel?.sectionModels?.forEach {
+        self._collectionViewModel?.sectionModels.forEach {
             if let header = $0.headerViewModel?.viewInfo {
                 switch header.registrationMethod {
                 case let .nib(name, bundle):

--- a/Sources/CollectionViewModel.swift
+++ b/Sources/CollectionViewModel.swift
@@ -80,14 +80,14 @@ public struct CollectionViewModel {
         }
     }
 
-    public let sectionModels: [SectionModel]?
+    public let sectionModels: [SectionModel]
 
-    public init(sectionModels: [SectionModel]?) {
+    public init(sectionModels: [SectionModel]) {
         self.sectionModels = sectionModels
     }
 
     public subscript(section: Int) -> SectionModel? {
-        guard let sectionModels = self.sectionModels, sectionModels.count > section else { return nil }
+        guard self.sectionModels.count > section else { return nil }
         return sectionModels[section]
     }
 

--- a/Sources/TableViewDataSource.swift
+++ b/Sources/TableViewDataSource.swift
@@ -108,7 +108,7 @@ open class TableViewDataSource: NSObject, UITableViewDataSource, UITableViewDele
     }
 
     public func numberOfSections(in tableView: UITableView) -> Int {
-        return self._tableViewModel?.sectionModels?.count ?? 0
+        return self._tableViewModel?.sectionModels.count ?? 0
     }
 
     public func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
@@ -291,7 +291,7 @@ open class TableViewDataSource: NSObject, UITableViewDataSource, UITableViewDele
     }
 
     func _registerHeaderFooterViews() {
-        self._tableViewModel?.sectionModels?.forEach {
+        self._tableViewModel?.sectionModels.forEach {
             if let header = $0.headerViewModel?.viewInfo {
                 switch header.registrationMethod {
                 case let .nib(name, bundle):

--- a/Sources/TableViewModel.swift
+++ b/Sources/TableViewModel.swift
@@ -75,21 +75,17 @@ public protocol TableViewSectionHeaderFooterViewModel {
 
 public struct TableViewModel {
     public let sectionIndexTitles: [String]?
-    public let sectionModels: [SectionModel]?
+    public let sectionModels: [SectionModel]
 
     public var isEmpty: Bool {
-        guard let models = self.sectionModels else {
-            return true
+        guard let cellViewModels = self.sectionModels.first?.cellViewModels else {
+            return self.sectionModels.isEmpty
         }
 
-        guard let cellViewModels = models.first?.cellViewModels else {
-            return models.isEmpty
-        }
-
-        return models.count == 1 && cellViewModels.isEmpty
+        return self.sectionModels.count == 1 && cellViewModels.isEmpty
     }
 
-    public init(sectionModels: [SectionModel]?, sectionIndexTitles: [String]? = nil) {
+    public init(sectionModels: [SectionModel], sectionIndexTitles: [String]? = nil) {
         self.sectionModels = sectionModels
         self.sectionIndexTitles = sectionIndexTitles
     }
@@ -100,7 +96,7 @@ public struct TableViewModel {
     }
 
     public subscript(section: Int) -> SectionModel? {
-        guard let sectionModels = self.sectionModels, sectionModels.count > section else { return nil }
+        guard sectionModels.count > section else { return nil }
         return sectionModels[ifExists: section]
     }
 
@@ -113,9 +109,8 @@ public struct TableViewModel {
     /// Provides a description of the table view content in terms of diffing keys. These diffing keys
     /// are used to calculate changesets in the table and animate changes automatically.
     var diffingKeys: SectionedValues<DiffingKey, DiffingKey> {
-        guard let sections = self.sectionModels else { return SectionedValues() }
         return SectionedValues(
-            sections.map { section in
+            self.sectionModels.map { section in
                 // Ensure we have a diffing key for the current section
                 guard let sectionDiffingKey = section.diffingKey else {
                     fatalError("When diffing is enabled you need to provide a non-nil diffingKey for each section.")


### PR DESCRIPTION
## Changes in this pull request

Noticed this while refactoring tests. Optionality of sections was unnecessary, as, in this case, the absence of sections can better be described by an empty array.

This cleans up the implementation quite a bit.