### PR TITLE
[Pod] Add Initial Podspec

### DIFF
--- a/ReactiveLists.podspec
+++ b/ReactiveLists.podspec
@@ -1,0 +1,16 @@
+Pod::Spec.new do |s|
+  s.name             = "ReactiveLists"
+  s.version          = "0.0.1"
+  s.summary          = "React-like API for UITableView and UICollectionView"
+  s.description      = "React-like API for UITableView and UICollectionView"
+  s.homepage         = "https://github.com/plangrid/ReactiveLists"
+  s.license          = { :type => "MIT", :file => "LICENSE.md" }
+  s.author           = "PlanGrid"
+  s.documentation_url = "https://plangrid.github.io/ReactiveLists"
+  s.social_media_url = "https://medium.com/plangrid-technology"
+  s.source           = { :git => "https://github.com/plangrid/ReactiveLists", :tag => s.version.to_s }
+  s.ios.deployment_target     = '9.0'
+  s.requires_arc = true
+  s.source_files     = 'Sources/**/*.swift'
+  s.dependency 'Dwifft', '~> 0.7.0'
+end


### PR DESCRIPTION
## Changes in this pull request

Adds an initial podspec that allows development of the `ReactiveLists-ReactiveSwift` extension.
