### PR TITLE
[TableDriver] Cleanup and organization

### DIFF
--- a/Sources/TableViewDriver.swift
+++ b/Sources/TableViewDriver.swift
@@ -19,7 +19,9 @@ import UIKit
 
 /// A Data Source that drives a dynamic table view's appereance and behavior in terms of view models for the individual cells.
 @objc
-open class TableViewDriver: NSObject, UITableViewDataSource, UITableViewDelegate {
+final public class TableViewDriver: NSObject {
+
+    // MARK: Properties
 
     /// Communicates information useful for refreshing the tableview
     ///
@@ -45,10 +47,11 @@ open class TableViewDriver: NSObject, UITableViewDataSource, UITableViewDelegate
     }
 
     private var _tableViewDiffer: TableViewDiffCalculator<DiffingKey, DiffingKey>?
-
-    private let _shouldDeselectUponSelection: Bool
     private let _automaticDiffingEnabled: Bool
+    private let _shouldDeselectUponSelection: Bool
     private var _didReceiveFirstNonNilValue = false
+
+    // MARK: Initialization
 
     public init(
         tableView: UITableView,
@@ -65,6 +68,62 @@ open class TableViewDriver: NSObject, UITableViewDataSource, UITableViewDelegate
         tableView.delegate = self
         self._tableViewModelDidChange()
     }
+
+    // MARK: Methods
+
+    public func refreshViews(refreshContext: TableRefreshContext = .unknown) {
+        guard let sections = self.tableViewModel?.sectionModels, !sections.isEmpty else {
+            return
+        }
+
+        let visibleIndexPaths = self.tableView.indexPathsForVisibleRows ?? []
+
+        // Collect the index paths and views models to reload
+        let indexPathsAndViewModelsToReload: [(IndexPath, TableViewCellViewModel)]
+        indexPathsAndViewModelsToReload = visibleIndexPaths.flatMap { indexPath in
+            return self.tableViewModel?[indexPath].map { (indexPath, $0) }
+        }
+
+        if !indexPathsAndViewModelsToReload.isEmpty {
+            // If there was a diff (or we don't know if there was one), then we can't do a
+            // beginUpdates/endUpdates-type reload: either one already happened, or we'll
+            // inadvertently cause a crash because we may not know that some rows are being
+            // added/deleted
+            for (indexPath, viewModel) in indexPathsAndViewModelsToReload {
+                guard let cell = self.tableView.cellForRow(at: indexPath) else { continue }
+                viewModel.applyViewModelToCell(cell)
+                cell.accessibilityIdentifier = viewModel.accessibilityFormat.accessibilityIdentifierForIndexPath(indexPath)
+            }
+
+            if refreshContext == .contentOnly {
+                // If we're only updating content (i.e. no diff that would call begin/end updates)
+                // call begin/end updates to ensure that row heights get a chance to update
+                // Note: begin/end updates sometimes re-queries the data source, but not always,
+                //       which is why we have to force refresh cells individually above
+                self.tableView.beginUpdates()
+                self.tableView.endUpdates()
+            }
+        }
+
+        let visibleSections = Set<Int>(visibleIndexPaths.map { $0.section })
+        for section in visibleSections {
+            guard let sectionModel = self.tableViewModel?[section] else { continue }
+
+            if let headerView = self.tableView.headerView(forSection: section),
+                let headerViewModel = sectionModel.headerViewModel {
+                headerViewModel.applyViewModelToView(headerView)
+                headerView.accessibilityIdentifier = headerViewModel.viewInfo?.accessibilityFormat.accessibilityIdentifierForSection(section)
+            }
+
+            if let footerView = self.tableView.footerView(forSection: section),
+                let footerViewModel = sectionModel.footerViewModel {
+                footerViewModel.applyViewModelToView(footerView)
+                footerView.accessibilityIdentifier = footerViewModel.viewInfo?.accessibilityFormat.accessibilityIdentifierForSection(section)
+            }
+        }
+    }
+
+    // MARK: Private
 
     private func _tableViewModelDidChange() {
         self._registerHeaderFooterViews()
@@ -125,46 +184,23 @@ open class TableViewDriver: NSObject, UITableViewDataSource, UITableViewDelegate
         }
     }
 
-    public func sectionIndexTitles(for tableView: UITableView) -> [String]? {
-        return self.tableViewModel?.sectionIndexTitles
+    private func _tableView(_ tableView: UITableView, viewForSection section: Int, viewKind: SupplementaryViewKind) -> UIView? {
+        guard let sectionModel = self.tableViewModel?[section],
+            let viewModel = viewKind == .header ? sectionModel.headerViewModel : sectionModel.footerViewModel,
+            let identifier = viewModel.viewInfo?.reuseIdentifier,
+            let view = tableView.dequeueReusableHeaderFooterView(withIdentifier: identifier) else {
+                return nil
+        }
+        viewModel.applyViewModelToView(view)
+        view.accessibilityIdentifier = viewModel.viewInfo?.accessibilityFormat.accessibilityIdentifierForSection(section)
+        return view
     }
+}
 
-    public func numberOfSections(in tableView: UITableView) -> Int {
-        return self.tableViewModel?.sectionModels.count ?? 0
-    }
+extension TableViewDriver: UITableViewDataSource {
 
-    public func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        guard let sectionModel = self.tableViewModel?[section], !sectionModel.collapsed else { return 0 }
-        return sectionModel.cellViewModels?.count ?? 0
-    }
-
-    open func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        return self.tableViewModel?[section]?.headerViewModel?.height ?? CGFloat.leastNormalMagnitude
-    }
-
-    public func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
-        return self.tableViewModel?[section]?.footerViewModel?.height ?? CGFloat.leastNormalMagnitude
-    }
-
-    public func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
-        guard let header = self.tableViewModel?[section]?.headerViewModel, header.viewInfo == nil else { return nil }
-        return header.title
-    }
-
-    public func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
-        guard let footer = self.tableViewModel?[section]?.footerViewModel, footer.viewInfo == nil else { return nil }
-        return footer.title
-    }
-
-    public func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        return self._tableView(tableView, viewForSection: section, viewKind: .header)
-    }
-
-    public func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
-        return self._tableView(tableView, viewForSection: section, viewKind: .footer)
-    }
-
-    open func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+    /// :nodoc:
+    public func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         var cell: UITableViewCell
 
         if let cellViewModel = self.tableViewModel?[indexPath] {
@@ -178,117 +214,112 @@ open class TableViewDriver: NSObject, UITableViewDataSource, UITableViewDelegate
         return cell
     }
 
-    open func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        return self.tableViewModel?[indexPath]?.rowHeight ?? 44
+    /// :nodoc:
+    public func numberOfSections(in tableView: UITableView) -> Int {
+        return self.tableViewModel?.sectionModels.count ?? 0
     }
 
-    public func tableView(_ tableView: UITableView, willBeginEditingRowAt indexPath: IndexPath) {
-        self.tableViewModel?[indexPath]?.willBeginEditing?()
+    /// :nodoc:
+    public func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        guard let sectionModel = self.tableViewModel?[section], !sectionModel.collapsed else { return 0 }
+        return sectionModel.cellViewModels?.count ?? 0
     }
 
-    public func tableView(_ tableView: UITableView, didEndEditingRowAt indexPath: IndexPath?) {
-        if let indexPath = indexPath {
-            self.tableViewModel?[indexPath]?.didEndEditing?()
-        }
+    /// :nodoc:
+    public func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        guard let header = self.tableViewModel?[section]?.headerViewModel, header.viewInfo == nil else { return nil }
+        return header.title
     }
 
-    public func tableView(_ tableView: UITableView, editingStyleForRowAt indexPath: IndexPath) -> UITableViewCellEditingStyle {
-        return self.tableViewModel?[indexPath]?.editingStyle ?? .none
+    /// :nodoc:
+    public func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
+        guard let footer = self.tableViewModel?[section]?.footerViewModel, footer.viewInfo == nil else { return nil }
+        return footer.title
     }
 
-    public func tableView(_ tableView: UITableView, editActionsForRowAt indexPath: IndexPath) -> [UITableViewRowAction]? {
-
-        if let cellViewModel = self.tableViewModel?[indexPath] as? TableViewCellModelEditActions {
-            return cellViewModel.editActions(indexPath)
-        }
-
-        return nil
-    }
-
-    public func tableView(_ tableView: UITableView, accessoryButtonTappedForRowWith indexPath: IndexPath) {
-        self.tableViewModel?[indexPath]?.accessoryButtonTappedClosure?()
-    }
-
-    public func tableView(_ tableView: UITableView, shouldHighlightRowAt indexPath: IndexPath) -> Bool {
-        return self.tableViewModel?[indexPath]?.shouldHighlight ?? true
-    }
-
+    /// :nodoc:
     public func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCellEditingStyle, forRowAt indexPath: IndexPath) {
         self.tableViewModel?[indexPath]?.commitEditingStyle?(editingStyle)
     }
 
-    open func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+    /// :nodoc:
+    public func sectionIndexTitles(for tableView: UITableView) -> [String]? {
+        return self.tableViewModel?.sectionIndexTitles
+    }
+}
+
+extension TableViewDriver: UITableViewDelegate {
+
+    /// :nodoc:
+    public func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        return self.tableViewModel?[indexPath]?.rowHeight ?? 44
+    }
+
+    /// :nodoc:
+    public func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        return self._tableView(tableView, viewForSection: section, viewKind: .header)
+    }
+
+    /// :nodoc:
+    public func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
+        return self._tableView(tableView, viewForSection: section, viewKind: .footer)
+    }
+
+    /// :nodoc:
+    public func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        return self.tableViewModel?[section]?.headerViewModel?.height ?? CGFloat.leastNormalMagnitude
+    }
+
+    /// :nodoc:
+    public func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
+        return self.tableViewModel?[section]?.footerViewModel?.height ?? CGFloat.leastNormalMagnitude
+    }
+
+    /// :nodoc:
+    public func tableView(_ tableView: UITableView, editActionsForRowAt indexPath: IndexPath) -> [UITableViewRowAction]? {
+        if let cellViewModel = self.tableViewModel?[indexPath] as? TableViewCellModelEditActions {
+            return cellViewModel.editActions(indexPath)
+        }
+        return nil
+    }
+
+    /// :nodoc:
+    public func tableView(_ tableView: UITableView, accessoryButtonTappedForRowWith indexPath: IndexPath) {
+        self.tableViewModel?[indexPath]?.accessoryButtonTappedClosure?()
+    }
+
+    /// :nodoc:
+    public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         if self._shouldDeselectUponSelection {
             tableView.deselectRow(at: indexPath, animated: true)
         }
         self.tableViewModel?[indexPath]?.didSelectClosure?()
     }
 
+    /// :nodoc:
+    public func tableView(_ tableView: UITableView, willBeginEditingRowAt indexPath: IndexPath) {
+        self.tableViewModel?[indexPath]?.willBeginEditing?()
+    }
+
+    /// :nodoc:
+    public func tableView(_ tableView: UITableView, didEndEditingRowAt indexPath: IndexPath?) {
+        if let indexPath = indexPath {
+            self.tableViewModel?[indexPath]?.didEndEditing?()
+        }
+    }
+
+    /// :nodoc:
+    public func tableView(_ tableView: UITableView, editingStyleForRowAt indexPath: IndexPath) -> UITableViewCellEditingStyle {
+        return self.tableViewModel?[indexPath]?.editingStyle ?? .none
+    }
+
+    /// :nodoc:
     public func tableView(_ tableView: UITableView, shouldIndentWhileEditingRowAt indexPath: IndexPath) -> Bool {
         return self.tableViewModel?[indexPath]?.shouldIndentWhileEditing ?? true
     }
 
-    public func refreshViews(refreshContext: TableRefreshContext = .unknown) {
-        guard let sections = self.tableViewModel?.sectionModels, !sections.isEmpty else {
-            return
-        }
-
-        let visibleIndexPaths = self.tableView.indexPathsForVisibleRows ?? []
-
-        // Collect the index paths and views models to reload
-        let indexPathsAndViewModelsToReload: [(IndexPath, TableViewCellViewModel)]
-        indexPathsAndViewModelsToReload = visibleIndexPaths.flatMap { indexPath in
-            return self.tableViewModel?[indexPath].map { (indexPath, $0) }
-        }
-
-        if !indexPathsAndViewModelsToReload.isEmpty {
-            // If there was a diff (or we don't know if there was one), then we can't do a
-            // beginUpdates/endUpdates-type reload: either one already happened, or we'll
-            // inadvertently cause a crash because we may not know that some rows are being
-            // added/deleted
-            for (indexPath, viewModel) in indexPathsAndViewModelsToReload {
-                guard let cell = self.tableView.cellForRow(at: indexPath) else { continue }
-                viewModel.applyViewModelToCell(cell)
-                cell.accessibilityIdentifier = viewModel.accessibilityFormat.accessibilityIdentifierForIndexPath(indexPath)
-            }
-
-            if refreshContext == .contentOnly {
-                // If we're only updating content (i.e. no diff that would call begin/end updates)
-                // call begin/end updates to ensure that row heights get a chance to update
-                // Note: begin/end updates sometimes re-queries the data source, but not always,
-                //       which is why we have to force refresh cells individually above
-                self.tableView.beginUpdates()
-                self.tableView.endUpdates()
-            }
-        }
-
-        let visibleSections = Set<Int>(visibleIndexPaths.map { $0.section })
-        for section in visibleSections {
-            guard let sectionModel = self.tableViewModel?[section] else { continue }
-
-            if let headerView = self.tableView.headerView(forSection: section),
-                let headerViewModel = sectionModel.headerViewModel {
-                headerViewModel.applyViewModelToView(headerView)
-                headerView.accessibilityIdentifier = headerViewModel.viewInfo?.accessibilityFormat.accessibilityIdentifierForSection(section)
-            }
-
-            if let footerView = self.tableView.footerView(forSection: section),
-                let footerViewModel = sectionModel.footerViewModel {
-                footerViewModel.applyViewModelToView(footerView)
-                footerView.accessibilityIdentifier = footerViewModel.viewInfo?.accessibilityFormat.accessibilityIdentifierForSection(section)
-            }
-        }
-    }
-
-    open func _tableView(_ tableView: UITableView, viewForSection section: Int, viewKind: SupplementaryViewKind) -> UIView? {
-        guard let sectionModel = self.tableViewModel?[section],
-            let viewModel = viewKind == .header ? sectionModel.headerViewModel : sectionModel.footerViewModel,
-            let identifier = viewModel.viewInfo?.reuseIdentifier,
-            let view = tableView.dequeueReusableHeaderFooterView(withIdentifier: identifier) else {
-                return nil
-        }
-        viewModel.applyViewModelToView(view)
-        view.accessibilityIdentifier = viewModel.viewInfo?.accessibilityFormat.accessibilityIdentifierForSection(section)
-        return view
+    /// :nodoc:
+    public func tableView(_ tableView: UITableView, shouldHighlightRowAt indexPath: IndexPath) -> Bool {
+        return self.tableViewModel?[indexPath]?.shouldHighlight ?? true
     }
 }


### PR DESCRIPTION
- refine access control
- remove `open`
- make class `final`
- add `// MARK:`s
- organize `DataSource` and `Delegate` methods in extensions
- add `/// :nodoc:` for data source and delegate methods so jazzy ignores them
