### PR TITLE
[Cleanup/Docs] Cleanups for Model Layer

### DIFF
--- a/Example/CollectionViewCells.swift
+++ b/Example/CollectionViewCells.swift
@@ -42,11 +42,10 @@ struct CollectionToolCellModel: CollectionViewCellViewModel, DiffableViewModel {
         }
     }
 
-    func applyViewModelToCell(_ cell: UICollectionViewCell) -> UICollectionViewCell {
-        guard let collectionToolCell = cell as? CollectionToolCell else { return cell }
+    func applyViewModelToCell(_ cell: UICollectionViewCell) {
+        guard let collectionToolCell = cell as? CollectionToolCell else { return }
         collectionToolCell.toolNameLabel.text = self.tool.type.name
         collectionToolCell.emojiLabel.text = self.tool.type.emoji
-        return collectionToolCell
     }
 
     var diffingKey: String {

--- a/Example/TableViewCells.swift
+++ b/Example/TableViewCells.swift
@@ -35,9 +35,8 @@ struct ToolTableCellModel: TableViewCellViewModel, DiffableViewModel {
         }
     }
 
-    func applyViewModelToCell(_ cell: UITableViewCell) -> UITableViewCell {
+    func applyViewModelToCell(_ cell: UITableViewCell) {
         cell.textLabel?.text = "\(self.tool.type.emoji) \(self.tool.type.name)"
-        return cell
     }
 
     var diffingKey: String {

--- a/ReactiveLists.xcodeproj/project.pbxproj
+++ b/ReactiveLists.xcodeproj/project.pbxproj
@@ -35,7 +35,7 @@
 		258E31D31F0D8F3100D6F324 /* AccessibilityFormats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 258E31D11F0D8F3100D6F324 /* AccessibilityFormats.swift */; };
 		258E31D41F0D8F3100D6F324 /* SupplementaryViewInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 258E31D21F0D8F3100D6F324 /* SupplementaryViewInfo.swift */; };
 		25B1B0B920195F1C0036545F /* CollectionViewDriverDiffingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25B1B0B720195F160036545F /* CollectionViewDriverDiffingTests.swift */; };
-		25B1B0BA201A53CF0036545F /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32124A712019312200EE12FC /* Utils.swift */; };
+		25B1B0BA201A53CF0036545F /* Typealiases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32124A712019312200EE12FC /* Typealiases.swift */; };
 		351B0BB920168E2E0034569D /* CollectionViewCells.swift in Sources */ = {isa = PBXBuildFile; fileRef = 351B0BB420168D2E0034569D /* CollectionViewCells.swift */; };
 		351B0BBA20168E2E0034569D /* CollectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 351B0BB320168D2E0034569D /* CollectionViewController.swift */; };
 		357B96DA201934C50000443F /* CollectionToolCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 357B96D9201934C50000443F /* CollectionToolCell.xib */; };
@@ -113,7 +113,7 @@
 		25B1B0B720195F160036545F /* CollectionViewDriverDiffingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionViewDriverDiffingTests.swift; sourceTree = "<group>"; };
 		276442FEC917A7E0F32CE5B4 /* Pods-ReactiveLists-ReactiveListsExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ReactiveLists-ReactiveListsExample.debug.xcconfig"; path = "Pods/Target Support Files/Pods-ReactiveLists-ReactiveListsExample/Pods-ReactiveLists-ReactiveListsExample.debug.xcconfig"; sourceTree = "<group>"; };
 		2F35530D29268B112F99A187 /* Pods_ReactiveLists_ReactiveListsExample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ReactiveLists_ReactiveListsExample.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		32124A712019312200EE12FC /* Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
+		32124A712019312200EE12FC /* Typealiases.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Typealiases.swift; sourceTree = "<group>"; };
 		351B0BB320168D2E0034569D /* CollectionViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CollectionViewController.swift; sourceTree = "<group>"; };
 		351B0BB420168D2E0034569D /* CollectionViewCells.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CollectionViewCells.swift; sourceTree = "<group>"; };
 		357B96D9201934C50000443F /* CollectionToolCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CollectionToolCell.xib; sourceTree = "<group>"; };
@@ -261,7 +261,7 @@
 				258E31D21F0D8F3100D6F324 /* SupplementaryViewInfo.swift */,
 				258E31AE1F0D8D9C00D6F324 /* TableViewDriver.swift */,
 				258E31AF1F0D8D9C00D6F324 /* TableViewModel.swift */,
-				32124A712019312200EE12FC /* Utils.swift */,
+				32124A712019312200EE12FC /* Typealiases.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -621,7 +621,7 @@
 				258E31D31F0D8F3100D6F324 /* AccessibilityFormats.swift in Sources */,
 				258E31D41F0D8F3100D6F324 /* SupplementaryViewInfo.swift in Sources */,
 				258E31B21F0D8D9C00D6F324 /* CollectionViewModel.swift in Sources */,
-				25B1B0BA201A53CF0036545F /* Utils.swift in Sources */,
+				25B1B0BA201A53CF0036545F /* Typealiases.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/CollectionViewModel.swift
+++ b/Sources/CollectionViewModel.swift
@@ -26,8 +26,7 @@ public protocol CollectionViewCellViewModel {
     var didSelectClosure: DidSelectClosure? { get }
     var didDeselectClosure: DidDeselectClosure? { get }
 
-    @discardableResult
-    func applyViewModelToCell(_ cell: UICollectionViewCell) -> UICollectionViewCell
+    func applyViewModelToCell(_ cell: UICollectionViewCell)
 }
 
 public extension CollectionViewCellViewModel {

--- a/Sources/TableViewDriver.swift
+++ b/Sources/TableViewDriver.swift
@@ -316,7 +316,7 @@ extension TableViewDriver: UITableViewDelegate {
 
     /// :nodoc:
     public func tableView(_ tableView: UITableView, accessoryButtonTappedForRowWith indexPath: IndexPath) {
-        self.tableViewModel?[indexPath]?.accessoryButtonTappedClosure?()
+        self.tableViewModel?[indexPath]?.accessoryButtonTapped?()
     }
 
     /// :nodoc:
@@ -324,7 +324,7 @@ extension TableViewDriver: UITableViewDelegate {
         if self._shouldDeselectUponSelection {
             tableView.deselectRow(at: indexPath, animated: true)
         }
-        self.tableViewModel?[indexPath]?.didSelectClosure?()
+        self.tableViewModel?[indexPath]?.didSelect?()
     }
 
     /// :nodoc:

--- a/Sources/TableViewModel.swift
+++ b/Sources/TableViewModel.swift
@@ -17,32 +17,35 @@
 import Dwifft
 import UIKit
 
-public typealias CommitEditingStyleClosure = (UITableViewCellEditingStyle) -> Void
-public typealias DidSelectClosure = () -> Void
-public typealias DidDeleteClosure = () -> Void
-public typealias DidDeselectClosure = () -> Void
-public typealias WillBeginEditingClosure = () -> Void
-public typealias DidEndEditingClosure = () -> Void
-public typealias AccessoryButtonTappedClosure = () -> Void
-
-/// View models for the individual cells of a `TableViewDataSource` driven table view
+/// View models for the individual cells of a `TableViewModel`.
 public protocol TableViewCellViewModel {
-    /// `TableViewDataSource` will automatically apply an `accessibilityIdentifier` to the cell based on this format
+    /// `TableViewDriver` will automatically apply an `accessibilityIdentifier` to the cell based on this format.
     var accessibilityFormat: CellAccessibilityFormat { get }
-
+    /// The reuse identifier for this cell.
     var cellIdentifier: String { get }
+    /// The height of this cell.
     var rowHeight: CGFloat { get }
-    var willBeginEditing: WillBeginEditingClosure? { get }
-    var didEndEditing: DidEndEditingClosure? { get }
+    /// The editing style for this cell.
     var editingStyle: UITableViewCellEditingStyle { get }
+    /// Whether or not this cell should be highlighted.
     var shouldHighlight: Bool { get }
-    var commitEditingStyle: CommitEditingStyleClosure? { get }
-    var didSelectClosure: DidSelectClosure? { get }
-    var accessoryButtonTappedClosure: AccessoryButtonTappedClosure? { get }
+    /// Whether or not this cell should be indented while editing.
     var shouldIndentWhileEditing: Bool { get }
+    /// Invoked when a cell will begin being edited.
+    var willBeginEditing: WillBeginEditingClosure? { get }
+    /// Invoked when cell editing has ended.
+    var didEndEditing: DidEndEditingClosure? { get }
+    /// Asks the cell to commit the insertion/deletion.
+    var commitEditingStyle: CommitEditingStyleClosure? { get }
+    /// Invoked when a cell has been selected.
+    var didSelect: DidSelectClosure? { get }
+    /// Invoked when an accessory button is tapped.
+    var accessoryButtonTapped: AccessoryButtonTappedClosure? { get }
 
-    @discardableResult
-    func applyViewModelToCell(_ cell: UITableViewCell) -> UITableViewCell
+    /// Asks the cell model to update the `UITableViewCell` with the content
+    /// in the cell model and return the updated cell.
+    /// - Parameter cell: the cell which contents need to be updated.
+    func applyViewModelToCell(_ cell: UITableViewCell)
 }
 
 /// Default implementations for the protocol
@@ -51,14 +54,14 @@ public extension TableViewCellViewModel {
         return 44.0
     }
 
-    var willBeginEditing: WillBeginEditingClosure? { return nil }
-    var didEndEditing: DidEndEditingClosure? { return nil }
     var editingStyle: UITableViewCellEditingStyle { return .none }
     var shouldHighlight: Bool { return true }
-    var commitEditingStyle: CommitEditingStyleClosure? { return nil }
-    var didSelectClosure: DidSelectClosure? { return nil }
-    var accessoryButtonTappedClosure: AccessoryButtonTappedClosure? { return nil }
     var shouldIndentWhileEditing: Bool { return false }
+    var willBeginEditing: WillBeginEditingClosure? { return nil }
+    var didEndEditing: DidEndEditingClosure? { return nil }
+    var commitEditingStyle: CommitEditingStyleClosure? { return nil }
+    var didSelect: DidSelectClosure? { return nil }
+    var accessoryButtonTapped: AccessoryButtonTappedClosure? { return nil }
 }
 
 public protocol TableViewCellModelEditActions {
@@ -69,7 +72,6 @@ public protocol TableViewSectionHeaderFooterViewModel {
     var title: String? { get }
     var height: CGFloat? { get }
     var viewInfo: SupplementaryViewInfo? { get }
-
     func applyViewModelToView(_ view: UIView)
 }
 

--- a/Sources/Typealiases.swift
+++ b/Sources/Typealiases.swift
@@ -17,3 +17,11 @@
 import Foundation
 
 public typealias Section = Int
+
+public typealias CommitEditingStyleClosure = (UITableViewCellEditingStyle) -> Void
+public typealias DidSelectClosure = () -> Void
+public typealias DidDeleteClosure = () -> Void
+public typealias DidDeselectClosure = () -> Void
+public typealias WillBeginEditingClosure = () -> Void
+public typealias DidEndEditingClosure = () -> Void
+public typealias AccessoryButtonTappedClosure = () -> Void

--- a/Tests/CollectionView/CollectionViewDriverDiffingTests.swift
+++ b/Tests/CollectionView/CollectionViewDriverDiffingTests.swift
@@ -133,9 +133,7 @@ struct CollectionUserCellModel: CollectionViewCellViewModel, DiffableViewModel {
         self.user = user
     }
 
-    func applyViewModelToCell(_ cell: UICollectionViewCell) -> UICollectionViewCell {
-        return cell
-    }
+    func applyViewModelToCell(_ cell: UICollectionViewCell) { }
 
     var diffingKey: String {
         return self.user.uuid.uuidString

--- a/Tests/Fixtures/TestCollectionViewModels.swift
+++ b/Tests/Fixtures/TestCollectionViewModels.swift
@@ -26,10 +26,9 @@ struct TestCollectionCellViewModel: CollectionViewCellViewModel {
     let accessibilityFormat: CellAccessibilityFormat = "access-%{section}.%{row}"
     let shouldHighlight = false
 
-    func applyViewModelToCell(_ cell: UICollectionViewCell) -> UICollectionViewCell {
-        guard let testCell = cell as? TestCollectionViewCell else { return cell }
+    func applyViewModelToCell(_ cell: UICollectionViewCell) {
+        guard let testCell = cell as? TestCollectionViewCell else { return }
         testCell.label = self.label
-        return testCell
     }
 }
 

--- a/Tests/Fixtures/TestTableViewModels.swift
+++ b/Tests/Fixtures/TestTableViewModels.swift
@@ -46,10 +46,9 @@ struct TestCellViewModel: TableViewCellViewModel {
         self.didSelectClosure = didSelectClosure
     }
 
-    func applyViewModelToCell(_ cell: UITableViewCell) -> UITableViewCell {
-        guard let testCell = cell as? TestTableViewCell else { return cell }
+    func applyViewModelToCell(_ cell: UITableViewCell) {
+        guard let testCell = cell as? TestTableViewCell else { return }
         testCell.label = self.label
-        return testCell
     }
 }
 

--- a/Tests/TableView/TableViewDiffingTests.swift
+++ b/Tests/TableView/TableViewDiffingTests.swift
@@ -105,9 +105,7 @@ struct UserCell: TableViewCellViewModel, DiffableViewModel {
         self.user = user
     }
 
-    func applyViewModelToCell(_ cell: UITableViewCell) -> UITableViewCell {
-        return cell
-    }
+    func applyViewModelToCell(_ cell: UITableViewCell) {}
 
     var diffingKey: String {
         return self.user

--- a/Tests/TableView/TableViewDriverTests.swift
+++ b/Tests/TableView/TableViewDriverTests.swift
@@ -264,7 +264,7 @@ final class TableViewDriverTests: XCTestCase {
         struct DefaultCellViewModel: TableViewCellViewModel {
             var accessibilityFormat: CellAccessibilityFormat = "_"
             var cellIdentifier: String = "_"
-            func applyViewModelToCell(_ cell: UITableViewCell) -> UITableViewCell { return cell }
+            func applyViewModelToCell(_ cell: UITableViewCell) { }
         }
 
         let defaultCellViewModel = DefaultCellViewModel()
@@ -275,8 +275,8 @@ final class TableViewDriverTests: XCTestCase {
         XCTAssertEqual(defaultCellViewModel.rowHeight, 44.0)
         XCTAssertTrue(defaultCellViewModel.shouldHighlight)
         XCTAssertNil(defaultCellViewModel.commitEditingStyle)
-        XCTAssertNil(defaultCellViewModel.didSelectClosure)
-        XCTAssertNil(defaultCellViewModel.accessoryButtonTappedClosure)
+        XCTAssertNil(defaultCellViewModel.didSelect)
+        XCTAssertNil(defaultCellViewModel.accessoryButtonTapped)
         XCTAssertFalse(defaultCellViewModel.shouldIndentWhileEditing)
     }
 }

--- a/Tests/TableView/TableViewMocks.swift
+++ b/Tests/TableView/TableViewMocks.swift
@@ -82,9 +82,9 @@ extension TableViewDriver {
 class MockCellViewModel: TableViewCellViewModel {
     var accessibilityFormat: CellAccessibilityFormat = "_"
     var cellIdentifier = "_"
-    func applyViewModelToCell(_ cell: UITableViewCell) -> UITableViewCell { return cell }
+    func applyViewModelToCell(_ cell: UITableViewCell) { }
 
-    var didSelectClosure: DidSelectClosure?
+    var didSelect: DidSelectClosure?
     var didSelectCalled = false
     var willBeginEditing: WillBeginEditingClosure?
     var willBeginEditingCalled = false
@@ -94,7 +94,7 @@ class MockCellViewModel: TableViewCellViewModel {
     var commitEditingStyleCalled: UITableViewCellEditingStyle?
 
     init() {
-        self.didSelectClosure = { [unowned self] in self.didSelectCalled = true }
+        self.didSelect = { [unowned self] in self.didSelectCalled = true }
         self.willBeginEditing = { [unowned self] in self.willBeginEditingCalled = true }
         self.didEndEditing = { [unowned self] in self.didEndEditingCalled = true }
         self.commitEditingStyle = { [unowned self] in self.commitEditingStyleCalled = $0 }


### PR DESCRIPTION
## Changes in this pull request

- `applyViewModelToCell` no longer has a return value. That return value was never used and could never be used, as that method is called to update a cell that is currently on screen. The API was misleading as it seemed possible to return an entirely new cell.
- Dropped “Closure” from all `TableViewCellModel` properties as that was redundant
- Documented `TableViewCellModel`
- Moved all typealiases into one file