### PR TITLE
Table cleanup and fix empty state, #48

### DIFF
--- a/Sources/AccessibilityFormats.swift
+++ b/Sources/AccessibilityFormats.swift
@@ -63,7 +63,7 @@ public struct SupplementaryAccessibilityFormat: ExpressibleByStringLiteral {
         self._format = value
     }
 
-    public func accessibilityIdentifierForSection(_ section: Section) -> String {
+    public func accessibilityIdentifierForSection(_ section: Int) -> String {
         return self._format.replacingOccurrences(of: "%{section}", with: String(section))
     }
 }

--- a/Sources/TableViewDriver.swift
+++ b/Sources/TableViewDriver.swift
@@ -154,6 +154,8 @@ open class TableViewDriver: NSObject {
         }
     }
 
+    // MARK: Private
+
     private func _tableViewModelDidChange() {
         self._registerHeaderFooterViews()
 
@@ -192,8 +194,6 @@ open class TableViewDriver: NSObject {
         }
     }
 
-    // MARK: Private helper methods
-
     private func _registerHeaderFooterViews() {
         self.tableViewModel?.sectionModels.forEach {
             if let header = $0.headerViewModel?.viewInfo {
@@ -215,7 +215,7 @@ open class TableViewDriver: NSObject {
         }
     }
 
-    open func _tableView(_ tableView: UITableView, viewForSection section: Int, viewKind: SupplementaryViewKind) -> UIView? {
+    private func _tableView(_ tableView: UITableView, viewForSection section: Int, viewKind: SupplementaryViewKind) -> UIView? {
         guard let sectionModel = self.tableViewModel?[section],
             let viewModel = viewKind == .header ? sectionModel.headerViewModel : sectionModel.footerViewModel,
             let identifier = viewModel.viewInfo?.reuseIdentifier,
@@ -249,7 +249,7 @@ extension TableViewDriver: UITableViewDataSource {
     /// :nodoc:
     public func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         guard let sectionModel = self.tableViewModel?[section], !sectionModel.collapsed else { return 0 }
-        return sectionModel.cellViewModels?.count ?? 0
+        return sectionModel.cellViewModels.count
     }
 
     /// :nodoc:

--- a/Sources/Typealiases.swift
+++ b/Sources/Typealiases.swift
@@ -16,8 +16,6 @@
 
 import Foundation
 
-public typealias Section = Int
-
 public typealias CommitEditingStyleClosure = (UITableViewCellEditingStyle) -> Void
 public typealias DidSelectClosure = () -> Void
 public typealias DidDeleteClosure = () -> Void

--- a/Tests/TableView/TableViewDriverTests.swift
+++ b/Tests/TableView/TableViewDriverTests.swift
@@ -36,7 +36,7 @@ final class TableViewDriverTests: XCTestCase {
     private func setupWithTableView(_ tableView: UITableView) {
         self._tableViewModel = TableViewModel(sectionModels: [
             TableViewSectionViewModel(
-                cellViewModels: nil,
+                cellViewModels: [],
                 headerViewModel: TestHeaderFooterViewModel(height: 10, viewKind: .header, label: "A"),
                 footerViewModel: TestHeaderFooterViewModel(height: 11, viewKind: .footer, label: "A"),
                 collapsed: false),

--- a/Tests/TableView/TableViewModelTests.swift
+++ b/Tests/TableView/TableViewModelTests.swift
@@ -27,7 +27,7 @@ final class TableViewModelTests: XCTestCase {
             TableViewSectionViewModel(
                 headerTitle: "section_1",
                 headerHeight: 42,
-                cellViewModels: nil),
+                cellViewModels: []),
             TableViewSectionViewModel(
                 headerTitle: "section_2",
                 headerHeight: 43,
@@ -76,7 +76,7 @@ final class TableViewModelTests: XCTestCase {
             footerHeight: 43
         )
 
-        XCTAssertEqual(sectionModel.cellViewModels?.count, 1)
+        XCTAssertEqual(sectionModel.cellViewModels.count, 1)
         XCTAssertEqual(sectionModel.headerViewModel?.height, 42)
         XCTAssertEqual(sectionModel.footerViewModel?.height, 43)
         XCTAssertFalse(sectionModel.collapsed)
@@ -96,7 +96,7 @@ final class TableViewModelTests: XCTestCase {
             collapsed: true
         )
 
-        XCTAssertEqual(sectionModel.cellViewModels?.count, 1)
+        XCTAssertEqual(sectionModel.cellViewModels.count, 1)
         XCTAssertEqual(sectionModel.headerViewModel?.height, 42)
         XCTAssertEqual(sectionModel.footerViewModel?.height, 43)
         XCTAssertEqual(sectionModel.headerViewModel?.title, "title_header+A")


### PR DESCRIPTION
- Make `SectionModel.cellViewModels` **not** optional, can use `isEmpty` instead
- Remove `typealias Section`. Only used once and provides no value.
