### PR TITLE
[Naming] Use *ViewModel Consistently

### DIFF
--- a/Example/CollectionViewController.swift
+++ b/Example/CollectionViewController.swift
@@ -75,7 +75,7 @@ extension CollectionViewController {
     /// Pure function mapping new state to a new `CollectionViewModel`.  This is invoked each time the state updates
     /// in order for ReactiveLists to update the UI.
     static func viewModel(forState groups: [ToolGroup], onDeleteClosure: @escaping (Tool) -> Void) -> CollectionViewModel {
-        let sections: [CollectionViewModel.SectionModel] = groups.map { group in
+        let sections: [CollectionViewSectionViewModel] = groups.map { group in
             let cellViewModels = group.tools.map { CollectionToolCellModel(tool: $0, onDeleteClosure: onDeleteClosure) }
             let headerViewModel = CollectionViewHeaderModel(
                 title: group.name,
@@ -86,7 +86,7 @@ extension CollectionViewController {
                     accessibilityFormat: "CollectionViewHeaderView"
                 )
             )
-            return CollectionViewModel.SectionModel(cellViewModels: cellViewModels, headerViewModel: headerViewModel, footerHeight: nil, diffingKey: group.name)
+            return CollectionViewSectionViewModel(cellViewModels: cellViewModels, headerViewModel: headerViewModel, footerHeight: nil, diffingKey: group.name)
         }
         return CollectionViewModel(sectionModels: sections)
     }

--- a/Example/TableViewController.swift
+++ b/Example/TableViewController.swift
@@ -70,9 +70,9 @@ extension TableViewController {
     /// Pure function mapping new state to a new `TableViewModel`.  This is invoked each time the state updates
     /// in order for ReactiveLists to update the UI.
     static func viewModel(forState groups: [ToolGroup], onDeleteClosure: @escaping (Tool) -> Void) -> TableViewModel {
-        let sections: [TableViewModel.SectionModel] = groups.map { group in
+        let sections: [TableViewSectionViewModel] = groups.map { group in
             let cellViewModels = group.tools.map { ToolTableCellModel(tool: $0, onDeleteClosure: onDeleteClosure) }
-            return TableViewModel.SectionModel(
+            return TableViewSectionViewModel(
                 headerTitle: group.name,
                 headerHeight: 44,
                 cellViewModels: cellViewModels,

--- a/Sources/CollectionViewModel.swift
+++ b/Sources/CollectionViewModel.swift
@@ -54,13 +54,13 @@ public extension CollectionViewSupplementaryViewModel {
 
 public struct CollectionViewModel {
 
-    public let sectionModels: [SectionModel]
+    public let sectionModels: [CollectionViewSectionViewModel]
 
-    public init(sectionModels: [SectionModel]) {
+    public init(sectionModels: [CollectionViewSectionViewModel]) {
         self.sectionModels = sectionModels
     }
 
-    public subscript(section: Int) -> SectionModel? {
+    public subscript(section: Int) -> CollectionViewSectionViewModel? {
         guard self.sectionModels.count > section else { return nil }
         return sectionModels[section]
     }
@@ -95,37 +95,35 @@ public struct CollectionViewModel {
     }
 }
 
-extension CollectionViewModel {
-    public struct SectionModel {
-        private struct BlankSupplementaryViewModel: CollectionViewSupplementaryViewModel {
-            let height: CGFloat?
-            let viewInfo: SupplementaryViewInfo? = nil
+public struct CollectionViewSectionViewModel {
+    private struct BlankSupplementaryViewModel: CollectionViewSupplementaryViewModel {
+        let height: CGFloat?
+        let viewInfo: SupplementaryViewInfo? = nil
 
-            func applyViewModelToView(_ view: UICollectionReusableView) { }
-        }
+        func applyViewModelToView(_ view: UICollectionReusableView) { }
+    }
 
-        let cellViewModels: [CollectionViewCellViewModel]?
-        let headerViewModel: CollectionViewSupplementaryViewModel?
-        let footerViewModel: CollectionViewSupplementaryViewModel?
-        public var diffingKey: String?
+    let cellViewModels: [CollectionViewCellViewModel]?
+    let headerViewModel: CollectionViewSupplementaryViewModel?
+    let footerViewModel: CollectionViewSupplementaryViewModel?
+    public var diffingKey: String?
 
-        public init(
-            cellViewModels: [CollectionViewCellViewModel]?,
-            headerViewModel: CollectionViewSupplementaryViewModel? = nil,
-            footerViewModel: CollectionViewSupplementaryViewModel? = nil,
-            diffingKey: String? = nil
-            ) {
-            self.cellViewModels = cellViewModels
-            self.headerViewModel = headerViewModel
-            self.footerViewModel = footerViewModel
-            self.diffingKey = diffingKey
-        }
+    public init(
+        cellViewModels: [CollectionViewCellViewModel]?,
+        headerViewModel: CollectionViewSupplementaryViewModel? = nil,
+        footerViewModel: CollectionViewSupplementaryViewModel? = nil,
+        diffingKey: String? = nil
+        ) {
+        self.cellViewModels = cellViewModels
+        self.headerViewModel = headerViewModel
+        self.footerViewModel = footerViewModel
+        self.diffingKey = diffingKey
     }
 }
 
 // MARK: Initializers without header/footer view models
 
-extension CollectionViewModel.SectionModel {
+extension CollectionViewSectionViewModel {
 
     public init(
         cellViewModels: [CollectionViewCellViewModel]?,

--- a/Sources/TableViewModel.swift
+++ b/Sources/TableViewModel.swift
@@ -75,11 +75,70 @@ public protocol TableViewSectionHeaderFooterViewModel {
     func applyViewModelToView(_ view: UIView)
 }
 
+/// View model for a table view section.
+public struct TableViewSectionViewModel {
+    /// Cells to be shown in this section.
+    public let cellViewModels: [TableViewCellViewModel]?
+    /// View model for the header of this section.
+    public let headerViewModel: TableViewSectionHeaderFooterViewModel?
+    /// View model for the footer of this section.
+    public let footerViewModel: TableViewSectionHeaderFooterViewModel?
+    /// Indicates whether or not this section is collapsed.
+    public var collapsed: Bool = false
+    /// The key used by the diffing algorithm to uniquely identify this section.
+    /// If you are using automatic diffing on the `TableViewDriver` (which is enabled by default)
+    /// you are required to provide a key that uniquely identifies this section.
+    ///
+    /// Typically you want to base this diffing key on data that is stored in the model.
+    /// For example:
+    ///
+    ///      public var diffingKey = { group.identifier }
+    public var diffingKey: String?
+
+    public init(
+        cellViewModels: [TableViewCellViewModel]?,
+        headerViewModel: TableViewSectionHeaderFooterViewModel? = nil,
+        footerViewModel: TableViewSectionHeaderFooterViewModel? = nil,
+        collapsed: Bool = false,
+        diffingKey: String? = nil
+        ) {
+        self.cellViewModels = cellViewModels
+        self.headerViewModel = headerViewModel
+        self.footerViewModel = footerViewModel
+        self.collapsed = collapsed
+        self.diffingKey = diffingKey
+    }
+
+    public init(
+        headerTitle: String?,
+        headerHeight: CGFloat?,
+        cellViewModels: [TableViewCellViewModel]?,
+        footerTitle: String? = nil,
+        footerHeight: CGFloat? = 0,
+        diffingKey: String? = nil
+        ) {
+        self.cellViewModels = cellViewModels
+        self.headerViewModel = PlainHeaderFooterViewModel(title: headerTitle, height: headerHeight)
+        self.footerViewModel = PlainHeaderFooterViewModel(title: footerTitle, height: footerHeight)
+        self.diffingKey = diffingKey
+    }
+}
+
+// MARK: Private
+
+private struct PlainHeaderFooterViewModel: TableViewSectionHeaderFooterViewModel {
+    let title: String?
+    let height: CGFloat?
+    let viewInfo: SupplementaryViewInfo? = nil
+
+    func applyViewModelToView(_ view: UIView) {}
+}
+
 public struct TableViewModel {
     /// The secion index titles for this table view.
     public let sectionIndexTitles: [String]?
     /// The section view models for this table view.
-    public let sectionModels: [SectionModel]
+    public let sectionModels: [TableViewSectionViewModel]
     /// Helper function that returns `true` if this table has no sections or has
     /// a single section with no cells.
     public var isEmpty: Bool {
@@ -95,7 +154,7 @@ public struct TableViewModel {
     ///
     /// - Parameter cellViewModels: the cell models for the only section in this table.
     public init(cellViewModels: [TableViewCellViewModel]?) {
-        let section = SectionModel(cellViewModels: cellViewModels, diffingKey: "default_section")
+        let section = TableViewSectionViewModel(cellViewModels: cellViewModels, diffingKey: "default_section")
         self.init(sectionModels: [section])
     }
 
@@ -105,7 +164,7 @@ public struct TableViewModel {
     /// - Parameters:
     ///   - sectionModels: the sections that need to be shown in this table.
     ///   - sectionIndexTitles: the section index titles for this table.
-    public init(sectionModels: [SectionModel], sectionIndexTitles: [String]? = nil) {
+    public init(sectionModels: [TableViewSectionViewModel], sectionIndexTitles: [String]? = nil) {
         if let sectionIndexTitles = sectionIndexTitles {
             assert(
                 sectionModels.count == sectionIndexTitles.count,
@@ -119,7 +178,7 @@ public struct TableViewModel {
     /// Returns the section model at the specified index or `nil` if no such section exists.
     ///
     /// - Parameter section: the index for the section that is being retrieved
-    public subscript(section: Int) -> SectionModel? {
+    public subscript(section: Int) -> TableViewSectionViewModel? {
         guard sectionModels.count > section else { return nil }
         return sectionModels[section]
     }
@@ -157,67 +216,5 @@ public struct TableViewModel {
                 return (sectionDiffingKey, cellDiffingKeys)
             }
         )
-    }
-}
-
-extension TableViewModel {
-
-    /// View model for a table view section.
-    public struct SectionModel {
-        /// Cells to be shown in this section.
-        public let cellViewModels: [TableViewCellViewModel]?
-        /// View model for the header of this section.
-        public let headerViewModel: TableViewSectionHeaderFooterViewModel?
-        /// View model for the footer of this section.
-        public let footerViewModel: TableViewSectionHeaderFooterViewModel?
-        /// Indicates whether or not this section is collapsed.
-        public var collapsed: Bool = false
-        /// The key used by the diffing algorithm to uniquely identify this section.
-        /// If you are using automatic diffing on the `TableViewDriver` (which is enabled by default)
-        /// you are required to provide a key that uniquely identifies this section.
-        ///
-        /// Typically you want to base this diffing key on data that is stored in the model.
-        /// For example:
-        ///
-        ///      public var diffingKey = { group.identifier }
-        public var diffingKey: String?
-
-        public init(
-            cellViewModels: [TableViewCellViewModel]?,
-            headerViewModel: TableViewSectionHeaderFooterViewModel? = nil,
-            footerViewModel: TableViewSectionHeaderFooterViewModel? = nil,
-            collapsed: Bool = false,
-            diffingKey: String? = nil
-        ) {
-            self.cellViewModels = cellViewModels
-            self.headerViewModel = headerViewModel
-            self.footerViewModel = footerViewModel
-            self.collapsed = collapsed
-            self.diffingKey = diffingKey
-        }
-
-        public init(
-            headerTitle: String?,
-            headerHeight: CGFloat?,
-            cellViewModels: [TableViewCellViewModel]?,
-            footerTitle: String? = nil,
-            footerHeight: CGFloat? = 0,
-            diffingKey: String? = nil
-        ) {
-            self.cellViewModels = cellViewModels
-            self.headerViewModel = PlainHeaderFooterViewModel(title: headerTitle, height: headerHeight)
-            self.footerViewModel = PlainHeaderFooterViewModel(title: footerTitle, height: footerHeight)
-            self.diffingKey = diffingKey
-        }
-    }
-
-    // MARK: Private
-
-    private struct PlainHeaderFooterViewModel: TableViewSectionHeaderFooterViewModel {
-        let title: String?
-        let height: CGFloat?
-        let viewInfo: SupplementaryViewInfo? = nil
-
-        func applyViewModelToView(_ view: UIView) {}
     }
 }

--- a/Tests/CollectionView/CollectionViewDriverDiffingTests.swift
+++ b/Tests/CollectionView/CollectionViewDriverDiffingTests.swift
@@ -43,7 +43,7 @@ final class CollectionViewDriverDiffingTests: XCTestCase {
     func testChangingRows() {
         let initialModel = CollectionViewModel(
             sectionModels: [
-                CollectionViewModel.SectionModel(
+                CollectionViewSectionViewModel(
                     cellViewModels: [],
                     headerHeight: 44,
                     footerHeight: 44,
@@ -56,7 +56,7 @@ final class CollectionViewDriverDiffingTests: XCTestCase {
 
         let updatedModel = CollectionViewModel(
             sectionModels: [
-                CollectionViewModel.SectionModel(
+                CollectionViewSectionViewModel(
                     cellViewModels: [CollectionUserCellModel(user: User(name: "Mona"))],
                     headerHeight: 44,
                     footerHeight: 44,
@@ -83,13 +83,13 @@ final class CollectionViewDriverDiffingTests: XCTestCase {
     func testChangingSections() {
         let initialModel = CollectionViewModel(
             sectionModels: [
-                CollectionViewModel.SectionModel(
+                CollectionViewSectionViewModel(
                     cellViewModels: [],
                     headerHeight: 44,
                     footerHeight: 44,
                     diffingKey: "1"
                 ),
-                CollectionViewModel.SectionModel(
+                CollectionViewSectionViewModel(
                     cellViewModels: [],
                     headerHeight: 44,
                     footerHeight: 44,
@@ -102,7 +102,7 @@ final class CollectionViewDriverDiffingTests: XCTestCase {
 
         let updatedModel = CollectionViewModel(
             sectionModels: [
-                CollectionViewModel.SectionModel(
+                CollectionViewSectionViewModel(
                     cellViewModels: [],
                     headerHeight: 44,
                     footerHeight: 44,

--- a/Tests/CollectionView/CollectionViewDriverTests.swift
+++ b/Tests/CollectionView/CollectionViewDriverTests.swift
@@ -31,19 +31,19 @@ final class CollectionViewDriverTests: XCTestCase {
         super.setUp()
         self._collectionView = TestCollectionView(frame: CGRect.zero, collectionViewLayout: UICollectionViewLayout())
         self._collectionViewModel = CollectionViewModel(sectionModels: [
-            CollectionViewModel.SectionModel(
+            CollectionViewSectionViewModel(
                 cellViewModels: nil,
                 headerViewModel: TestCollectionViewSupplementaryViewModel(height: 10, viewKind: .header, sectionLabel: "A"),
                 footerViewModel: TestCollectionViewSupplementaryViewModel(height: 11, viewKind: .footer, sectionLabel: "A")),
-            CollectionViewModel.SectionModel(
+            CollectionViewSectionViewModel(
                 cellViewModels: ["A", "B", "C"].map { self._generateTestCollectionCellViewModel($0) },
                 headerViewModel: nil,
                 footerViewModel: TestCollectionViewSupplementaryViewModel(label: "footer_B", height: 21)),
-            CollectionViewModel.SectionModel(
+            CollectionViewSectionViewModel(
                 cellViewModels: ["D", "E", "F"].map { self._generateTestCollectionCellViewModel($0) },
                 headerViewModel: TestCollectionViewSupplementaryViewModel(label: "header_C", height: 30),
                 footerViewModel: nil),
-            CollectionViewModel.SectionModel(
+            CollectionViewSectionViewModel(
                 cellViewModels: nil,
                 headerViewModel: TestCollectionViewSupplementaryViewModel(height: nil, viewKind: .header, sectionLabel: "D"),
                 footerViewModel: TestCollectionViewSupplementaryViewModel(height: nil, viewKind: .footer, sectionLabel: "D")),
@@ -219,11 +219,11 @@ final class CollectionViewDriverTests: XCTestCase {
         XCTAssertEqual(footer?.label, "label_footer+A")
 
         self._collectionViewDataSource.collectionViewModel = CollectionViewModel(sectionModels: [
-            CollectionViewModel.SectionModel(
+            CollectionViewSectionViewModel(
                 cellViewModels: nil,
                 headerViewModel: TestCollectionViewSupplementaryViewModel(height: 10, viewKind: .header, sectionLabel: "X"),
                 footerViewModel: TestCollectionViewSupplementaryViewModel(height: 11, viewKind: .footer, sectionLabel: "X")),
-            CollectionViewModel.SectionModel(
+            CollectionViewSectionViewModel(
                 cellViewModels: [self._generateTestCollectionCellViewModel("X")],
                 headerViewModel: nil,
                 footerViewModel: nil),

--- a/Tests/CollectionView/CollectionViewModelTests.swift
+++ b/Tests/CollectionView/CollectionViewModelTests.swift
@@ -23,7 +23,7 @@ final class CollectionViewModelTests: XCTestCase {
     /// without specifying a header and footer view, wich results
     /// in a blank default view being used.
     func testViewModelInitalizerWithBlankHeaderAndFooter() {
-        let sectionModel = CollectionViewModel.SectionModel(
+        let sectionModel = CollectionViewSectionViewModel(
             cellViewModels: [generateTestCollectionCellViewModel()],
             headerHeight: 40,
             footerHeight: 50
@@ -40,7 +40,7 @@ final class CollectionViewModelTests: XCTestCase {
     /// without specifying a header view, wich results
     /// in a blank default view being used.
     func testViewModelInitializerWithBlankHeader() {
-        let sectionModel = CollectionViewModel.SectionModel(
+        let sectionModel = CollectionViewSectionViewModel(
             cellViewModels: [generateTestCollectionCellViewModel()],
             headerHeight: 40,
             footerViewModel: TestCollectionViewSupplementaryViewModel(
@@ -66,7 +66,7 @@ final class CollectionViewModelTests: XCTestCase {
     /// without specifying a footer view, wich results
     /// in a blank default view being used.
     func testViewModelInitializerWithBlankFooter() {
-        let sectionModel = CollectionViewModel.SectionModel(
+        let sectionModel = CollectionViewSectionViewModel(
             cellViewModels: [generateTestCollectionCellViewModel()],
             headerViewModel: TestCollectionViewSupplementaryViewModel(
                 height: 40,
@@ -90,7 +90,7 @@ final class CollectionViewModelTests: XCTestCase {
 
     /// Can be initialized with a custom header and footer view.
     func testViewModelInitializerWithCustomHeaderAndFooter() {
-        let sectionModel = CollectionViewModel.SectionModel(
+        let sectionModel = CollectionViewSectionViewModel(
             cellViewModels: [generateTestCollectionCellViewModel()],
             headerViewModel: TestCollectionViewSupplementaryViewModel(
                 height: 40,
@@ -125,11 +125,11 @@ final class CollectionViewModelTests: XCTestCase {
     /// model returns `nil`.
     func testSubscripts() {
         let collectionViewModel = CollectionViewModel(sectionModels: [
-            CollectionViewModel.SectionModel(
+            CollectionViewSectionViewModel(
                 cellViewModels: nil,
                 headerHeight: 42,
                 footerHeight: nil),
-            CollectionViewModel.SectionModel(
+            CollectionViewSectionViewModel(
                 cellViewModels: [
                     generateTestCollectionCellViewModel("A"),
                     generateTestCollectionCellViewModel("B"),

--- a/Tests/TableView/TableViewDiffingTests.swift
+++ b/Tests/TableView/TableViewDiffingTests.swift
@@ -66,11 +66,11 @@ final class TableViewDiffingTests: XCTestCase {
     ///   extensive tests for the various diffing scenarios.
     func testChangingSections() {
         let initialModel = TableViewModel(sectionModels: [
-            TableViewModel.SectionModel(
+            TableViewSectionViewModel(
                 cellViewModels: [],
                 diffingKey: "1"
             ),
-            TableViewModel.SectionModel(
+            TableViewSectionViewModel(
                 cellViewModels: [],
                 diffingKey: "2"
             ),
@@ -79,7 +79,7 @@ final class TableViewDiffingTests: XCTestCase {
         self.tableViewDataSource.tableViewModel = initialModel
 
         let updatedModel = TableViewModel(sectionModels: [
-            TableViewModel.SectionModel(
+            TableViewSectionViewModel(
                 cellViewModels: [],
                 diffingKey: "2"
             ),

--- a/Tests/TableView/TableViewDriverTests.swift
+++ b/Tests/TableView/TableViewDriverTests.swift
@@ -35,17 +35,17 @@ final class TableViewDriverTests: XCTestCase {
     /// the content described in the `TableViewModel`.
     private func setupWithTableView(_ tableView: UITableView) {
         self._tableViewModel = TableViewModel(sectionModels: [
-            TableViewModel.SectionModel(
+            TableViewSectionViewModel(
                 cellViewModels: nil,
                 headerViewModel: TestHeaderFooterViewModel(height: 10, viewKind: .header, label: "A"),
                 footerViewModel: TestHeaderFooterViewModel(height: 11, viewKind: .footer, label: "A"),
                 collapsed: false),
-            TableViewModel.SectionModel(
+            TableViewSectionViewModel(
                 cellViewModels: ["A", "B", "C"].map { _generateTestCellViewModel($0) },
                 headerViewModel: nil,
                 footerViewModel: TestHeaderFooterViewModel(title: "footer_2", height: 21),
                 collapsed: false),
-            TableViewModel.SectionModel(
+             TableViewSectionViewModel(
                 cellViewModels: ["D", "E", "F"].map { _generateTestCellViewModel($0) },
                 headerViewModel: TestHeaderFooterViewModel(title: "header_3", height: 30),
                 footerViewModel: nil,
@@ -289,11 +289,11 @@ private func _generateTestCellViewModel(_ label: String) -> TestCellViewModel {
 
 private func _generateTestTableViewModelForRefreshingViews() -> TableViewModel {
     return TableViewModel(sectionModels: [
-        TableViewModel.SectionModel(
+        TableViewSectionViewModel(
             cellViewModels: [_generateTestCellViewModel("X")],
             headerViewModel: TestHeaderFooterViewModel(height: 10, viewKind: .header, label: "X"),
             footerViewModel: TestHeaderFooterViewModel(height: 11, viewKind: .footer, label: "X")),
-        TableViewModel.SectionModel(
+        TableViewSectionViewModel(
             cellViewModels: ["Y", "Z"].map { _generateTestCellViewModel($0) },
             headerViewModel: TestHeaderFooterViewModel(height: 20, viewKind: .header, label: "Y"),
             footerViewModel: TestHeaderFooterViewModel(height: 21, viewKind: .footer, label: "Y")),

--- a/Tests/TableView/TableViewModelTests.swift
+++ b/Tests/TableView/TableViewModelTests.swift
@@ -24,11 +24,11 @@ final class TableViewModelTests: XCTestCase {
     /// model returns `nil`.
     func testSubscripts() {
         let tableViewModel = TableViewModel(sectionModels: [
-            TableViewModel.SectionModel(
+            TableViewSectionViewModel(
                 headerTitle: "section_1",
                 headerHeight: 42,
                 cellViewModels: nil),
-            TableViewModel.SectionModel(
+            TableViewSectionViewModel(
                 headerTitle: "section_2",
                 headerHeight: 43,
                 cellViewModels: [
@@ -56,7 +56,7 @@ final class TableViewModelTests: XCTestCase {
         XCTAssertTrue(tableViewModel1.isEmpty)
 
         let tableViewModel2 = TableViewModel(
-            sectionModels: [TableViewModel.SectionModel(
+            sectionModels: [TableViewSectionViewModel(
                 cellViewModels: []
             )]
         )
@@ -68,7 +68,7 @@ final class TableViewModelTests: XCTestCase {
     /// Table view sections can be successfully initialized
     /// using a plain section header.
     func testPlainHeaderFooterSectionModelInitalizer() {
-        let sectionModel = TableViewModel.SectionModel(
+        let sectionModel = TableViewSectionViewModel(
             headerTitle: "foo",
             headerHeight: 42,
             cellViewModels: [generateTestCellViewModel()],
@@ -89,7 +89,7 @@ final class TableViewModelTests: XCTestCase {
     /// Table view sections can be successfully initialized
     /// using a custom section header type.
     func testCustomHeaderFooterSectionModelInitalizer() {
-        let sectionModel = TableViewModel.SectionModel(
+        let sectionModel = TableViewSectionViewModel(
             cellViewModels: [generateTestCellViewModel()],
             headerViewModel: TestHeaderFooterViewModel(height: 42, viewKind: .header, label: "A"),
             footerViewModel: TestHeaderFooterViewModel(height: 43, viewKind: .footer, label: "A"),


### PR DESCRIPTION
Changes the names of all types that are view models to be consistent. Removes namespace nesting which was inconsistent.