### PR TITLE
Clean up, docs, renaming

### DIFF
--- a/Example/CollectionViewCells.swift
+++ b/Example/CollectionViewCells.swift
@@ -24,7 +24,7 @@ final class CollectionToolCell: UICollectionViewCell {
     @IBOutlet weak var closeButton: UIButton!
 }
 
-final class CollectionToolCellModel: CollectionViewCellViewModel, DiffableViewModel {
+final class CollectionToolCellModel: CollectionCellViewModel, DiffableViewModel {
 
     let accessibilityFormat: CellAccessibilityFormat = "CollectionToolCell"
     let registrationInfo = ViewRegistrationInfo(classType: CollectionToolCell.self, nibName: "CollectionToolCell")
@@ -65,7 +65,7 @@ final class CollectionViewHeaderView: UICollectionReusableView {
     @IBOutlet weak var headerLabel: UILabel!
 }
 
-struct CollectionViewHeaderModel: CollectionViewSupplementaryViewModel {
+struct CollectionViewHeaderModel: CollectionSupplementaryViewModel {
     var title: String?
     var height: CGFloat?
     var viewInfo: SupplementaryViewInfo?

--- a/Example/CollectionViewController.swift
+++ b/Example/CollectionViewController.swift
@@ -68,7 +68,7 @@ extension CollectionViewController {
     /// Pure function mapping new state to a new `CollectionViewModel`.  This is invoked each time the state updates
     /// in order for ReactiveLists to update the UI.
     static func viewModel(forState groups: [ToolGroup], onDeleteClosure: @escaping (Tool) -> Void) -> CollectionViewModel {
-        let sections: [CollectionViewSectionViewModel] = groups.map { group in
+        let sections: [CollectionSectionViewModel] = groups.map { group in
             let cellViewModels = group.tools.map { CollectionToolCellModel(tool: $0, onDeleteClosure: onDeleteClosure) }
             let headerViewModel = CollectionViewHeaderModel(
                 title: group.name,
@@ -79,7 +79,7 @@ extension CollectionViewController {
                     accessibilityFormat: "CollectionViewHeaderView"
                 )
             )
-            return CollectionViewSectionViewModel(cellViewModels: cellViewModels, headerViewModel: headerViewModel, footerHeight: nil, diffingKey: group.name)
+            return CollectionSectionViewModel(cellViewModels: cellViewModels, headerViewModel: headerViewModel, footerHeight: nil, diffingKey: group.name)
         }
         return CollectionViewModel(sectionModels: sections)
     }

--- a/ReactiveLists.xcodeproj/project.pbxproj
+++ b/ReactiveLists.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		25B1B0BA201A53CF0036545F /* Typealiases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32124A712019312200EE12FC /* Typealiases.swift */; };
 		3203532B201BE9E90024D6CC /* ToolTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32035329201BE99F0024D6CC /* ToolTableViewCell.swift */; };
 		3203532D201BF5FB0024D6CC /* CellContainerViewProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3203532C201BF5FB0024D6CC /* CellContainerViewProtocol.swift */; };
+		320B8FE82024E654002615F8 /* ReusableCellViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 320B8FE72024E654002615F8 /* ReusableCellViewModelProtocol.swift */; };
 		32753F8D201BB8310084DCB1 /* UICollectionView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32753F8C201BB8310084DCB1 /* UICollectionView+Extensions.swift */; };
 		32753F8F201BB8470084DCB1 /* UITableView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32753F8E201BB8470084DCB1 /* UITableView+Extensions.swift */; };
 		32E7A1F8201BADE800B90EBC /* ViewRegistrationInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32E7A1F7201BADE800B90EBC /* ViewRegistrationInfo.swift */; };
@@ -120,6 +121,7 @@
 		2F35530D29268B112F99A187 /* Pods_ReactiveLists_ReactiveListsExample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ReactiveLists_ReactiveListsExample.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		32035329201BE99F0024D6CC /* ToolTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolTableViewCell.swift; sourceTree = "<group>"; };
 		3203532C201BF5FB0024D6CC /* CellContainerViewProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CellContainerViewProtocol.swift; sourceTree = "<group>"; };
+		320B8FE72024E654002615F8 /* ReusableCellViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReusableCellViewModelProtocol.swift; sourceTree = "<group>"; };
 		32124A712019312200EE12FC /* Typealiases.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Typealiases.swift; sourceTree = "<group>"; };
 		32753F8C201BB8310084DCB1 /* UICollectionView+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UICollectionView+Extensions.swift"; sourceTree = "<group>"; };
 		32753F8E201BB8470084DCB1 /* UITableView+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableView+Extensions.swift"; sourceTree = "<group>"; };
@@ -270,6 +272,7 @@
 				2541B73C1F29A13B002C3090 /* Diffing.swift */,
 				258E31931F0D8CBC00D6F324 /* Info.plist */,
 				258E31921F0D8CBC00D6F324 /* ReactiveLists.h */,
+				320B8FE72024E654002615F8 /* ReusableCellViewModelProtocol.swift */,
 				258E31D21F0D8F3100D6F324 /* SupplementaryViewInfo.swift */,
 				258E31AE1F0D8D9C00D6F324 /* TableViewDriver.swift */,
 				258E31AF1F0D8D9C00D6F324 /* TableViewModel.swift */,
@@ -639,6 +642,7 @@
 				258E31B41F0D8D9C00D6F324 /* TableViewModel.swift in Sources */,
 				258E31D31F0D8F3100D6F324 /* AccessibilityFormats.swift in Sources */,
 				32753F8F201BB8470084DCB1 /* UITableView+Extensions.swift in Sources */,
+				320B8FE82024E654002615F8 /* ReusableCellViewModelProtocol.swift in Sources */,
 				258E31D41F0D8F3100D6F324 /* SupplementaryViewInfo.swift in Sources */,
 				258E31B21F0D8D9C00D6F324 /* CollectionViewModel.swift in Sources */,
 				25B1B0BA201A53CF0036545F /* Typealiases.swift in Sources */,

--- a/Sources/CellContainerViewProtocol.swift
+++ b/Sources/CellContainerViewProtocol.swift
@@ -43,13 +43,13 @@ protocol CellContainerViewProtocol {
 }
 
 extension CellContainerViewProtocol {
-    func registerCellViewModels(_ cellViewModels: [ReusableCellProtocol]) {
+    func registerCellViewModels(_ cellViewModels: [ReusableCellViewModelProtocol]) {
         cellViewModels.forEach {
             self.registerCellViewModel($0)
         }
     }
 
-    func registerCellViewModel(_ model: ReusableCellProtocol) {
+    func registerCellViewModel(_ model: ReusableCellViewModelProtocol) {
         let info = model.registrationInfo
         let identifier = info.reuseIdentifier
         let method = info.registrationMethod

--- a/Sources/CollectionViewModel.swift
+++ b/Sources/CollectionViewModel.swift
@@ -18,7 +18,7 @@ import Dwifft
 import UIKit
 
 /// View model for the individual cells of a `UICollectionView`.
-public protocol CollectionViewCellViewModel: ReusableCellProtocol {
+public protocol CollectionCellViewModel: ReusableCellViewModelProtocol {
 
     /// `CollectionViewDriver` will automatically apply an `accessibilityIdentifier` to the cell based on this format
     var accessibilityFormat: CellAccessibilityFormat { get }
@@ -39,14 +39,14 @@ public protocol CollectionViewCellViewModel: ReusableCellProtocol {
 }
 
 /// Default implementations for `CollectionViewCellViewModel`.
-public extension CollectionViewCellViewModel {
+public extension CollectionCellViewModel {
     var shouldHighlight: Bool { return true }
     var didSelect: DidSelectClosure? { return nil }
     var didDeselect: DidDeselectClosure? { return nil }
 }
 
 /// View model for supplementary views in collection views.
-public protocol CollectionViewSupplementaryViewModel: ReusableSupplementaryViewProtocol {
+public protocol CollectionSupplementaryViewModel: ReusableSupplementaryViewProtocol {
 
     /// Metadata for this supplementary view.
     var viewInfo: SupplementaryViewInfo? { get }
@@ -61,7 +61,7 @@ public protocol CollectionViewSupplementaryViewModel: ReusableSupplementaryViewP
 }
 
 /// Default implementations for `CollectionViewSupplementaryViewModel`.
-public extension CollectionViewSupplementaryViewModel {
+public extension CollectionSupplementaryViewModel {
     var viewInfo: SupplementaryViewInfo? { return nil }
     var height: CGFloat? { return nil }
 
@@ -72,19 +72,19 @@ public extension CollectionViewSupplementaryViewModel {
 public struct CollectionViewModel {
 
     /// The section view models for this collection view.
-    public let sectionModels: [CollectionViewSectionViewModel]
+    public let sectionModels: [CollectionSectionViewModel]
 
     /// Initializes a collection view model with the sections provided.
     ///
     /// - Parameter sectionModels: the sections that need to be shown in this collection view.
-    public init(sectionModels: [CollectionViewSectionViewModel]) {
+    public init(sectionModels: [CollectionSectionViewModel]) {
         self.sectionModels = sectionModels
     }
 
     /// Returns the section model at the specified index or `nil` if no such section exists.
     ///
     /// - Parameter section: the index for the section that is being retrieved
-    public subscript(section: Int) -> CollectionViewSectionViewModel? {
+    public subscript(section: Int) -> CollectionSectionViewModel? {
         guard self.sectionModels.count > section else { return nil }
         return sectionModels[section]
     }
@@ -92,7 +92,7 @@ public struct CollectionViewModel {
     /// Returns the cell view model at the specified index path or `nil` if no such cell exists.
     ///
     /// - Parameter indexPath: the index path for the cell that is being retrieved
-    public subscript(indexPath: IndexPath) -> CollectionViewCellViewModel? {
+    public subscript(indexPath: IndexPath) -> CollectionCellViewModel? {
         guard let section = self[indexPath.section], section.cellViewModels.count > indexPath.item else { return nil }
         return section.cellViewModels[indexPath.item]
     }
@@ -122,15 +122,15 @@ public struct CollectionViewModel {
 }
 
 /// View model for a collection view section.
-public struct CollectionViewSectionViewModel {
+public struct CollectionSectionViewModel {
 
     /// Cells to be shown in this section.
-    let cellViewModels: [CollectionViewCellViewModel]
+    let cellViewModels: [CollectionCellViewModel]
     /// View model for the header of this section.
-    let headerViewModel: CollectionViewSupplementaryViewModel?
+    let headerViewModel: CollectionSupplementaryViewModel?
 
     /// View model for the footer of this section.
-    let footerViewModel: CollectionViewSupplementaryViewModel?
+    let footerViewModel: CollectionSupplementaryViewModel?
 
     /// The key used by the diffing algorithm to uniquely identify this section.
     /// If you are using automatic diffing on the `CollectionViewDriver` (which is enabled by default)
@@ -150,18 +150,18 @@ public struct CollectionViewSectionViewModel {
     ///   - footerViewModel: the footer view model (defaults to `nil`).
     ///   - diffingKey: the diffing key, required for automated diffing.
     public init(
-        cellViewModels: [CollectionViewCellViewModel],
-        headerViewModel: CollectionViewSupplementaryViewModel? = nil,
-        footerViewModel: CollectionViewSupplementaryViewModel? = nil,
+        cellViewModels: [CollectionCellViewModel],
+        headerViewModel: CollectionSupplementaryViewModel? = nil,
+        footerViewModel: CollectionSupplementaryViewModel? = nil,
         diffingKey: String? = nil
-    ) {
+        ) {
         self.cellViewModels = cellViewModels
         self.headerViewModel = headerViewModel
         self.footerViewModel = footerViewModel
         self.diffingKey = diffingKey
     }
 
-    private struct BlankSupplementaryViewModel: CollectionViewSupplementaryViewModel {
+    private struct BlankSupplementaryViewModel: CollectionSupplementaryViewModel {
         let height: CGFloat?
         let viewInfo: SupplementaryViewInfo? = nil
 
@@ -175,15 +175,15 @@ public struct CollectionViewSectionViewModel {
 // to remove them. We want to get rid of the legacy functionality that creates
 // blank headers & footers instead of using spacing properties available via
 // `UICollectionViewLayout`s.
-extension CollectionViewSectionViewModel {
+extension CollectionSectionViewModel {
 
     /// :nodoc:
     public init(
-        cellViewModels: [CollectionViewCellViewModel],
+        cellViewModels: [CollectionCellViewModel],
         headerHeight: CGFloat? = nil,
-        footerViewModel: CollectionViewSupplementaryViewModel? = nil,
+        footerViewModel: CollectionSupplementaryViewModel? = nil,
         diffingKey: String? = nil
-    ) {
+        ) {
         self.init(
             cellViewModels: cellViewModels,
             headerViewModel: BlankSupplementaryViewModel(height: headerHeight),
@@ -194,11 +194,11 @@ extension CollectionViewSectionViewModel {
 
     /// :nodoc:
     public init(
-        cellViewModels: [CollectionViewCellViewModel],
-        headerViewModel: CollectionViewSupplementaryViewModel? = nil,
+        cellViewModels: [CollectionCellViewModel],
+        headerViewModel: CollectionSupplementaryViewModel? = nil,
         footerHeight: CGFloat? = nil,
         diffingKey: String? = nil
-    ) {
+        ) {
         self.init(
             cellViewModels: cellViewModels,
             headerViewModel: headerViewModel,
@@ -209,11 +209,11 @@ extension CollectionViewSectionViewModel {
 
     /// :nodoc:
     public init(
-        cellViewModels: [CollectionViewCellViewModel],
+        cellViewModels: [CollectionCellViewModel],
         headerHeight: CGFloat? = nil,
         footerHeight: CGFloat? = nil,
         diffingKey: String? = nil
-    ) {
+        ) {
         self.init(
             cellViewModels: cellViewModels,
             headerViewModel: BlankSupplementaryViewModel(height: headerHeight),

--- a/Sources/ReusableCellViewModelProtocol.swift
+++ b/Sources/ReusableCellViewModelProtocol.swift
@@ -1,0 +1,23 @@
+//
+//  PlanGrid
+//  https://www.plangrid.com
+//  https://medium.com/plangrid-technology
+//
+//  Documentation
+//  https://plangrid.github.io/ReactiveLists
+//
+//  GitHub
+//  https://github.com/plangrid/ReactiveLists
+//
+//  License
+//  Copyright © 2018-present PlanGrid, Inc.
+//  Released under an MIT license: https://opensource.org/licenses/MIT
+// 
+
+import Foundation
+
+public protocol ReusableCellViewModelProtocol {
+
+    /// The registration info for the cell.
+    var registrationInfo: ViewRegistrationInfo { get }
+}

--- a/Sources/TableViewModel.swift
+++ b/Sources/TableViewModel.swift
@@ -18,7 +18,7 @@ import Dwifft
 import UIKit
 
 /// View model for the individual cells of a `TableViewModel`.
-public protocol TableViewCellViewModel: ReusableCellProtocol {
+public protocol TableViewCellViewModel: ReusableCellViewModelProtocol {
 
     /// `TableViewDriver` will automatically apply an `accessibilityIdentifier` to the cell based on this format.
     var accessibilityFormat: CellAccessibilityFormat { get }

--- a/Sources/UICollectionView+Extensions.swift
+++ b/Sources/UICollectionView+Extensions.swift
@@ -32,7 +32,7 @@ extension UICollectionView {
         }
     }
 
-    func configuredCell(for model: CollectionViewCellViewModel, at indexPath: IndexPath) -> UICollectionViewCell {
+    func configuredCell(for model: CollectionCellViewModel, at indexPath: IndexPath) -> UICollectionViewCell {
         let cell = self.dequeueReusableCellFor(identifier: model.registrationInfo.reuseIdentifier, indexPath: indexPath)
         model.applyViewModelToCell(cell)
         cell.accessibilityIdentifier = model.accessibilityFormat.accessibilityIdentifierForIndexPath(indexPath)

--- a/Sources/ViewRegistrationInfo.swift
+++ b/Sources/ViewRegistrationInfo.swift
@@ -17,21 +17,37 @@
 import Foundation
 import UIKit
 
-public protocol ReusableCellProtocol {
-
-    /// The registration info for the cell.
-    var registrationInfo: ViewRegistrationInfo { get }
-}
-
+/// Describes the registration information for a cell or supplementary view.
 public struct ViewRegistrationInfo {
+
+    /// The reuse identifier for the view.
     let reuseIdentifier: String
+
+    /// The registration method for the view.
     let registrationMethod: ViewRegistrationMethod
 
+    /// Initializes a new `ViewRegistrationInfo` for the provided `classType`.
+    ///
+    /// - Note:
+    /// The class name is used for `reuseIdentifier`.
+    /// The `registrationMethod` is set to `.fromClass`.
+    ///
+    /// - Parameter classType: The cell or supplementary view class.
     public init(classType: AnyClass) {
         self.reuseIdentifier = "\(classType)"
         self.registrationMethod = .fromClass(classType)
     }
 
+    /// Initializes a new `ViewRegistrationInfo` for the provided `classType`, `nibName`, and `bundle`.
+    ///
+    /// - Note:
+    /// The class name is used for `reuseIdentifier`.
+    /// The `registrationMethod` is set to `.fromNib` using the provided `nibName` and `bundle`.
+    ///
+    /// - Parameters:
+    ///   - classType: The cell or supplementary view class.
+    ///   - nibName: The name of the nib for the view.
+    ///   - bundle: The bundle in which the nib is located. Pass `nil` to use the main bundle.
     public init(classType: AnyClass, nibName: String, bundle: Bundle? = nil) {
         self.reuseIdentifier = "\(classType)"
         self.registrationMethod = .fromNib(name: nibName, bundle: bundle)

--- a/Tests/CollectionView/CollectionViewDriverDiffingTests.swift
+++ b/Tests/CollectionView/CollectionViewDriverDiffingTests.swift
@@ -43,7 +43,7 @@ final class CollectionViewDriverDiffingTests: XCTestCase {
     func testChangingRows() {
         let initialModel = CollectionViewModel(
             sectionModels: [
-                CollectionViewSectionViewModel(
+                CollectionSectionViewModel(
                     cellViewModels: [],
                     headerHeight: 44,
                     footerHeight: 44,
@@ -56,7 +56,7 @@ final class CollectionViewDriverDiffingTests: XCTestCase {
 
         let updatedModel = CollectionViewModel(
             sectionModels: [
-                CollectionViewSectionViewModel(
+                CollectionSectionViewModel(
                     cellViewModels: [CollectionUserCellModel(user: User(name: "Mona"))],
                     headerHeight: 44,
                     footerHeight: 44,
@@ -83,13 +83,13 @@ final class CollectionViewDriverDiffingTests: XCTestCase {
     func testChangingSections() {
         let initialModel = CollectionViewModel(
             sectionModels: [
-                CollectionViewSectionViewModel(
+                CollectionSectionViewModel(
                     cellViewModels: [],
                     headerHeight: 44,
                     footerHeight: 44,
                     diffingKey: "1"
                 ),
-                CollectionViewSectionViewModel(
+                CollectionSectionViewModel(
                     cellViewModels: [],
                     headerHeight: 44,
                     footerHeight: 44,
@@ -102,7 +102,7 @@ final class CollectionViewDriverDiffingTests: XCTestCase {
 
         let updatedModel = CollectionViewModel(
             sectionModels: [
-                CollectionViewSectionViewModel(
+                CollectionSectionViewModel(
                     cellViewModels: [],
                     headerHeight: 44,
                     footerHeight: 44,
@@ -121,7 +121,7 @@ final class CollectionViewDriverDiffingTests: XCTestCase {
     }
 }
 
-struct CollectionUserCellModel: CollectionViewCellViewModel, DiffableViewModel {
+struct CollectionUserCellModel: CollectionCellViewModel, DiffableViewModel {
 
     var accessibilityFormat: CellAccessibilityFormat = "CollectionUserCell"
     var registrationInfo = ViewRegistrationInfo(classType: TestCollectionViewCell.self)

--- a/Tests/CollectionView/CollectionViewDriverTests.swift
+++ b/Tests/CollectionView/CollectionViewDriverTests.swift
@@ -31,19 +31,19 @@ final class CollectionViewDriverTests: XCTestCase {
         super.setUp()
         self._collectionView = TestCollectionView(frame: CGRect.zero, collectionViewLayout: UICollectionViewLayout())
         self._collectionViewModel = CollectionViewModel(sectionModels: [
-            CollectionViewSectionViewModel(
+            CollectionSectionViewModel(
                 cellViewModels: [],
                 headerViewModel: TestCollectionViewSupplementaryViewModel(height: 10, viewKind: .header, sectionLabel: "A"),
                 footerViewModel: TestCollectionViewSupplementaryViewModel(height: 11, viewKind: .footer, sectionLabel: "A")),
-            CollectionViewSectionViewModel(
+            CollectionSectionViewModel(
                 cellViewModels: ["A", "B", "C"].map { self._generateTestCollectionCellViewModel($0) },
                 headerViewModel: nil,
                 footerViewModel: TestCollectionViewSupplementaryViewModel(label: "footer_B", height: 21)),
-            CollectionViewSectionViewModel(
+            CollectionSectionViewModel(
                 cellViewModels: ["D", "E", "F"].map { self._generateTestCollectionCellViewModel($0) },
                 headerViewModel: TestCollectionViewSupplementaryViewModel(label: "header_C", height: 30),
                 footerViewModel: nil),
-            CollectionViewSectionViewModel(
+            CollectionSectionViewModel(
                 cellViewModels: [],
                 headerViewModel: TestCollectionViewSupplementaryViewModel(height: nil, viewKind: .header, sectionLabel: "D"),
                 footerViewModel: TestCollectionViewSupplementaryViewModel(height: nil, viewKind: .footer, sectionLabel: "D")),
@@ -208,11 +208,11 @@ final class CollectionViewDriverTests: XCTestCase {
         XCTAssertEqual(footer?.label, "label_footer+A")
 
         self._collectionViewDataSource.collectionViewModel = CollectionViewModel(sectionModels: [
-            CollectionViewSectionViewModel(
+            CollectionSectionViewModel(
                 cellViewModels: [],
                 headerViewModel: TestCollectionViewSupplementaryViewModel(height: 10, viewKind: .header, sectionLabel: "X"),
                 footerViewModel: TestCollectionViewSupplementaryViewModel(height: 11, viewKind: .footer, sectionLabel: "X")),
-            CollectionViewSectionViewModel(
+            CollectionSectionViewModel(
                 cellViewModels: [self._generateTestCollectionCellViewModel("X")],
                 headerViewModel: nil,
                 footerViewModel: nil),

--- a/Tests/CollectionView/CollectionViewModelTests.swift
+++ b/Tests/CollectionView/CollectionViewModelTests.swift
@@ -23,7 +23,7 @@ final class CollectionViewModelTests: XCTestCase {
     /// without specifying a header and footer view, wich results
     /// in a blank default view being used.
     func testViewModelInitalizerWithBlankHeaderAndFooter() {
-        let sectionModel = CollectionViewSectionViewModel(
+        let sectionModel = CollectionSectionViewModel(
             cellViewModels: [generateTestCollectionCellViewModel()],
             headerHeight: 40,
             footerHeight: 50
@@ -40,7 +40,7 @@ final class CollectionViewModelTests: XCTestCase {
     /// without specifying a header view, wich results
     /// in a blank default view being used.
     func testViewModelInitializerWithBlankHeader() {
-        let sectionModel = CollectionViewSectionViewModel(
+        let sectionModel = CollectionSectionViewModel(
             cellViewModels: [generateTestCollectionCellViewModel()],
             headerHeight: 40,
             footerViewModel: TestCollectionViewSupplementaryViewModel(
@@ -66,7 +66,7 @@ final class CollectionViewModelTests: XCTestCase {
     /// without specifying a footer view, wich results
     /// in a blank default view being used.
     func testViewModelInitializerWithBlankFooter() {
-        let sectionModel = CollectionViewSectionViewModel(
+        let sectionModel = CollectionSectionViewModel(
             cellViewModels: [generateTestCollectionCellViewModel()],
             headerViewModel: TestCollectionViewSupplementaryViewModel(
                 height: 40,
@@ -90,7 +90,7 @@ final class CollectionViewModelTests: XCTestCase {
 
     /// Can be initialized with a custom header and footer view.
     func testViewModelInitializerWithCustomHeaderAndFooter() {
-        let sectionModel = CollectionViewSectionViewModel(
+        let sectionModel = CollectionSectionViewModel(
             cellViewModels: [generateTestCollectionCellViewModel()],
             headerViewModel: TestCollectionViewSupplementaryViewModel(
                 height: 40,
@@ -125,11 +125,11 @@ final class CollectionViewModelTests: XCTestCase {
     /// model returns `nil`.
     func testSubscripts() {
         let collectionViewModel = CollectionViewModel(sectionModels: [
-            CollectionViewSectionViewModel(
+            CollectionSectionViewModel(
                 cellViewModels: [],
                 headerHeight: 42,
                 footerHeight: nil),
-            CollectionViewSectionViewModel(
+            CollectionSectionViewModel(
                 cellViewModels: [
                     generateTestCollectionCellViewModel("A"),
                     generateTestCollectionCellViewModel("B"),

--- a/Tests/Fixtures/TestCollectionViewModels.swift
+++ b/Tests/Fixtures/TestCollectionViewModels.swift
@@ -17,7 +17,7 @@
 import Foundation
 @testable import ReactiveLists
 
-struct TestCollectionCellViewModel: CollectionViewCellViewModel {
+struct TestCollectionCellViewModel: CollectionCellViewModel {
     let label: String
     let didSelect: DidSelectClosure?
     let didDeselect: DidDeselectClosure?
@@ -32,7 +32,7 @@ struct TestCollectionCellViewModel: CollectionViewCellViewModel {
     }
 }
 
-struct TestCollectionViewSupplementaryViewModel: CollectionViewSupplementaryViewModel {
+struct TestCollectionViewSupplementaryViewModel: CollectionSupplementaryViewModel {
     let label: String?
     let height: CGFloat?
     let viewInfo: SupplementaryViewInfo?


### PR DESCRIPTION
- Rename `ReusableCellProtocol` --> `ReusableCellViewModelProtocol`

Remove superfluous "view" in names:
- Rename `CollectionViewCellViewModel` --> `CollectionCellViewModel`
- Rename `CollectionViewSupplementaryViewModel` --> `CollectionSupplementaryViewModel`
- Rename `CollectionViewSectionViewModel` --> `CollectionSectionViewModel`

- Add docs for `ViewRegistrationInfo`
