### PR TITLE
Table component renames, similar to #104

### DIFF
--- a/Example/TableViewCellModels.swift
+++ b/Example/TableViewCellModels.swift
@@ -17,7 +17,7 @@
 import Foundation
 import ReactiveLists
 
-struct ToolTableCellModel: TableViewCellViewModel, DiffableViewModel {
+struct ToolTableCellModel: TableCellViewModel, DiffableViewModel {
     let registrationInfo = ViewRegistrationInfo(classType: ToolTableViewCell.self)
 
     let commitEditingStyle: CommitEditingStyleClosure?

--- a/Example/TableViewController.swift
+++ b/Example/TableViewController.swift
@@ -68,9 +68,9 @@ extension TableViewController {
     /// Pure function mapping new state to a new `TableViewModel`.  This is invoked each time the state updates
     /// in order for ReactiveLists to update the UI.
     static func viewModel(forState groups: [ToolGroup], onDeleteClosure: @escaping (Tool) -> Void) -> TableViewModel {
-        let sections: [TableViewSectionViewModel] = groups.map { group in
+        let sections: [TableSectionViewModel] = groups.map { group in
             let cellViewModels = group.tools.map { ToolTableCellModel(tool: $0, onDeleteClosure: onDeleteClosure) }
-            return TableViewSectionViewModel(
+            return TableSectionViewModel(
                 headerTitle: group.name,
                 headerHeight: 44,
                 cellViewModels: cellViewModels,

--- a/Sources/TableViewDriver.swift
+++ b/Sources/TableViewDriver.swift
@@ -110,7 +110,7 @@ open class TableViewDriver: NSObject {
         let visibleIndexPaths = self.tableView.indexPathsForVisibleRows ?? []
 
         // Collect the index paths and views models to reload
-        let indexPathsAndViewModelsToReload: [(IndexPath, TableViewCellViewModel)]
+        let indexPathsAndViewModelsToReload: [(IndexPath, TableCellViewModel)]
         indexPathsAndViewModelsToReload = visibleIndexPaths.flatMap { indexPath in
             return self.tableViewModel?[indexPath].map { (indexPath, $0) }
         }

--- a/Sources/TableViewModel.swift
+++ b/Sources/TableViewModel.swift
@@ -18,7 +18,7 @@ import Dwifft
 import UIKit
 
 /// View model for the individual cells of a `TableViewModel`.
-public protocol TableViewCellViewModel: ReusableCellViewModelProtocol {
+public protocol TableCellViewModel: ReusableCellViewModelProtocol {
 
     /// `TableViewDriver` will automatically apply an `accessibilityIdentifier` to the cell based on this format.
     var accessibilityFormat: CellAccessibilityFormat { get }
@@ -57,7 +57,7 @@ public protocol TableViewCellViewModel: ReusableCellViewModelProtocol {
 }
 
 /// Default implementations for the protocol.
-public extension TableViewCellViewModel {
+public extension TableCellViewModel {
     var rowHeight: CGFloat {
         return 44.0
     }
@@ -80,7 +80,7 @@ public protocol TableViewCellModelEditActions {
 
 /// Protocol that needs to be implemented by custom header
 /// footer view models.
-public protocol TableViewSectionHeaderFooterViewModel: ReusableSupplementaryViewProtocol {
+public protocol TableSectionHeaderFooterViewModel: ReusableSupplementaryViewProtocol {
 
     /// The title of the header
     var title: String? { get }
@@ -95,16 +95,16 @@ public protocol TableViewSectionHeaderFooterViewModel: ReusableSupplementaryView
 }
 
 /// View model for a table view section.
-public struct TableViewSectionViewModel {
+public struct TableSectionViewModel {
 
     /// Cells to be shown in this section.
-    public let cellViewModels: [TableViewCellViewModel]
+    public let cellViewModels: [TableCellViewModel]
 
     /// View model for the header of this section.
-    public let headerViewModel: TableViewSectionHeaderFooterViewModel?
+    public let headerViewModel: TableSectionHeaderFooterViewModel?
 
     /// View model for the footer of this section.
-    public let footerViewModel: TableViewSectionHeaderFooterViewModel?
+    public let footerViewModel: TableSectionHeaderFooterViewModel?
 
     /// Indicates whether or not this section is collapsed.
     public var collapsed: Bool = false
@@ -133,9 +133,9 @@ public struct TableViewSectionViewModel {
     ///   - collapsed: whether or not this section is collapsed (defaults to `false`).
     ///   - diffingKey: the diffing key, or `nil`. Required for automated diffing.
     public init(
-        cellViewModels: [TableViewCellViewModel],
-        headerViewModel: TableViewSectionHeaderFooterViewModel? = nil,
-        footerViewModel: TableViewSectionHeaderFooterViewModel? = nil,
+        cellViewModels: [TableCellViewModel],
+        headerViewModel: TableSectionHeaderFooterViewModel? = nil,
+        footerViewModel: TableSectionHeaderFooterViewModel? = nil,
         collapsed: Bool = false,
         diffingKey: String? = nil
     ) {
@@ -160,7 +160,7 @@ public struct TableViewSectionViewModel {
     public init(
         headerTitle: String?,
         headerHeight: CGFloat?,
-        cellViewModels: [TableViewCellViewModel],
+        cellViewModels: [TableCellViewModel],
         footerTitle: String? = nil,
         footerHeight: CGFloat? = 0,
         diffingKey: String? = nil
@@ -179,7 +179,7 @@ public struct TableViewModel {
     public let sectionIndexTitles: [String]?
 
     /// The section view models for this table view.
-    public let sectionModels: [TableViewSectionViewModel]
+    public let sectionModels: [TableSectionViewModel]
 
     /// Returns `true` if this table has no sections or has a single empty section.
     public var isEmpty: Bool {
@@ -193,8 +193,8 @@ public struct TableViewModel {
     /// via the initializer.
     ///
     /// - Parameter cellViewModels: the cell models for the only section in this table.
-    public init(cellViewModels: [TableViewCellViewModel]) {
-        let section = TableViewSectionViewModel(cellViewModels: cellViewModels, diffingKey: "default_section")
+    public init(cellViewModels: [TableCellViewModel]) {
+        let section = TableSectionViewModel(cellViewModels: cellViewModels, diffingKey: "default_section")
         self.init(sectionModels: [section])
     }
 
@@ -204,7 +204,7 @@ public struct TableViewModel {
     /// - Parameters:
     ///   - sectionModels: the sections that need to be shown in this table view.
     ///   - sectionIndexTitles: the section index titles for this table view.
-    public init(sectionModels: [TableViewSectionViewModel], sectionIndexTitles: [String]? = nil) {
+    public init(sectionModels: [TableSectionViewModel], sectionIndexTitles: [String]? = nil) {
         if let sectionIndexTitles = sectionIndexTitles {
             assert(
                 sectionModels.count == sectionIndexTitles.count,
@@ -218,7 +218,7 @@ public struct TableViewModel {
     /// Returns the section model at the specified index or `nil` if no such section exists.
     ///
     /// - Parameter section: the index for the section that is being retrieved
-    public subscript(section: Int) -> TableViewSectionViewModel? {
+    public subscript(section: Int) -> TableSectionViewModel? {
         guard sectionModels.count > section else { return nil }
         return sectionModels[section]
     }
@@ -226,7 +226,7 @@ public struct TableViewModel {
     /// Returns the cell view model at the specified index path or `nil` if no such cell exists.
     ///
     /// - Parameter indexPath: the index path for the cell that is being retrieved
-    public subscript(indexPath: IndexPath) -> TableViewCellViewModel? {
+    public subscript(indexPath: IndexPath) -> TableCellViewModel? {
         guard let section = self[indexPath.section],
             section.cellViewModels.count > indexPath.row else {
                 return nil
@@ -261,7 +261,7 @@ public struct TableViewModel {
 // MARK: Private
 
 /// View model for a default header or footer view in a table view.
-private struct PlainHeaderFooterViewModel: TableViewSectionHeaderFooterViewModel {
+private struct PlainHeaderFooterViewModel: TableSectionHeaderFooterViewModel {
     let title: String?
     let height: CGFloat?
     let viewInfo: SupplementaryViewInfo? = nil

--- a/Sources/UITableView+Extensions.swift
+++ b/Sources/UITableView+Extensions.swift
@@ -18,7 +18,7 @@ import UIKit
 
 extension UITableView {
 
-    func configuredCell(for model: TableViewCellViewModel, at indexPath: IndexPath) -> UITableViewCell {
+    func configuredCell(for model: TableCellViewModel, at indexPath: IndexPath) -> UITableViewCell {
         let cell = self.dequeueReusableCellFor(identifier: model.registrationInfo.reuseIdentifier, indexPath: indexPath)
         model.applyViewModelToCell(cell)
         cell.accessibilityIdentifier = model.accessibilityFormat.accessibilityIdentifierForIndexPath(indexPath)

--- a/Tests/Fixtures/TestTableViewModels.swift
+++ b/Tests/Fixtures/TestTableViewModels.swift
@@ -17,7 +17,7 @@
 import Foundation
 @testable import ReactiveLists
 
-struct TestCellViewModel: TableViewCellViewModel {
+struct TestCellViewModel: TableCellViewModel {
     let rowHeight: CGFloat = 42
     let editingStyle = UITableViewCellEditingStyle.delete
     let shouldHighlight = false
@@ -80,7 +80,7 @@ func generateTestCellViewModel(_ label: String? = nil) -> TestCellViewModel {
     )
 }
 
-struct TestHeaderFooterViewModel: TableViewSectionHeaderFooterViewModel {
+struct TestHeaderFooterViewModel: TableSectionHeaderFooterViewModel {
     let title: String?
     let height: CGFloat?
     let viewInfo: SupplementaryViewInfo?

--- a/Tests/TableView/TableViewDiffingTests.swift
+++ b/Tests/TableView/TableViewDiffingTests.swift
@@ -66,11 +66,11 @@ final class TableViewDiffingTests: XCTestCase {
     ///   extensive tests for the various diffing scenarios.
     func testChangingSections() {
         let initialModel = TableViewModel(sectionModels: [
-            TableViewSectionViewModel(
+            TableSectionViewModel(
                 cellViewModels: [],
                 diffingKey: "1"
             ),
-            TableViewSectionViewModel(
+            TableSectionViewModel(
                 cellViewModels: [],
                 diffingKey: "2"
             ),
@@ -79,7 +79,7 @@ final class TableViewDiffingTests: XCTestCase {
         self.tableViewDataSource.tableViewModel = initialModel
 
         let updatedModel = TableViewModel(sectionModels: [
-            TableViewSectionViewModel(
+            TableSectionViewModel(
                 cellViewModels: [],
                 diffingKey: "2"
             ),
@@ -95,7 +95,7 @@ final class TableViewDiffingTests: XCTestCase {
     }
 }
 
-struct UserCell: TableViewCellViewModel, DiffableViewModel {
+struct UserCell: TableCellViewModel, DiffableViewModel {
     var accessibilityFormat: CellAccessibilityFormat = ""
     let registrationInfo = ViewRegistrationInfo(classType: UITableViewCell.self)
 

--- a/Tests/TableView/TableViewDriverTests.swift
+++ b/Tests/TableView/TableViewDriverTests.swift
@@ -35,17 +35,17 @@ final class TableViewDriverTests: XCTestCase {
     /// the content described in the `TableViewModel`.
     private func setupWithTableView(_ tableView: UITableView) {
         self._tableViewModel = TableViewModel(sectionModels: [
-            TableViewSectionViewModel(
+            TableSectionViewModel(
                 cellViewModels: [],
                 headerViewModel: TestHeaderFooterViewModel(height: 10, viewKind: .header, label: "A"),
                 footerViewModel: TestHeaderFooterViewModel(height: 11, viewKind: .footer, label: "A"),
                 collapsed: false),
-            TableViewSectionViewModel(
+            TableSectionViewModel(
                 cellViewModels: ["A", "B", "C"].map { _generateTestCellViewModel($0) },
                 headerViewModel: nil,
                 footerViewModel: TestHeaderFooterViewModel(title: "footer_2", height: 21),
                 collapsed: false),
-             TableViewSectionViewModel(
+             TableSectionViewModel(
                 cellViewModels: ["D", "E", "F"].map { _generateTestCellViewModel($0) },
                 headerViewModel: TestHeaderFooterViewModel(title: "header_3", height: 30),
                 footerViewModel: nil,
@@ -259,7 +259,7 @@ final class TableViewDriverTests: XCTestCase {
     /// When providing a cell that implements the minimum protocol requirements,
     /// default values for certain properties are provided.
     func testTableViewCellViewModelDefaults() {
-        struct DefaultCellViewModel: TableViewCellViewModel {
+        struct DefaultCellViewModel: TableCellViewModel {
             var accessibilityFormat: CellAccessibilityFormat = "_"
             let registrationInfo = ViewRegistrationInfo(classType: UITableViewCell.self)
             func applyViewModelToCell(_ cell: UITableViewCell) { }
@@ -287,11 +287,11 @@ private func _generateTestCellViewModel(_ label: String) -> TestCellViewModel {
 
 private func _generateTestTableViewModelForRefreshingViews() -> TableViewModel {
     return TableViewModel(sectionModels: [
-        TableViewSectionViewModel(
+        TableSectionViewModel(
             cellViewModels: [_generateTestCellViewModel("X")],
             headerViewModel: TestHeaderFooterViewModel(height: 10, viewKind: .header, label: "X"),
             footerViewModel: TestHeaderFooterViewModel(height: 11, viewKind: .footer, label: "X")),
-        TableViewSectionViewModel(
+        TableSectionViewModel(
             cellViewModels: ["Y", "Z"].map { _generateTestCellViewModel($0) },
             headerViewModel: TestHeaderFooterViewModel(height: 20, viewKind: .header, label: "Y"),
             footerViewModel: TestHeaderFooterViewModel(height: 21, viewKind: .footer, label: "Y")),

--- a/Tests/TableView/TableViewMocks.swift
+++ b/Tests/TableView/TableViewMocks.swift
@@ -79,7 +79,7 @@ extension TableViewDriver {
     }
 }
 
-class MockCellViewModel: TableViewCellViewModel {
+class MockCellViewModel: TableCellViewModel {
     var accessibilityFormat: CellAccessibilityFormat = "_"
     let registrationInfo = ViewRegistrationInfo(classType: UITableViewCell.self)
     func applyViewModelToCell(_ cell: UITableViewCell) { }

--- a/Tests/TableView/TableViewModelTests.swift
+++ b/Tests/TableView/TableViewModelTests.swift
@@ -24,11 +24,11 @@ final class TableViewModelTests: XCTestCase {
     /// model returns `nil`.
     func testSubscripts() {
         let tableViewModel = TableViewModel(sectionModels: [
-            TableViewSectionViewModel(
+            TableSectionViewModel(
                 headerTitle: "section_1",
                 headerHeight: 42,
                 cellViewModels: []),
-            TableViewSectionViewModel(
+            TableSectionViewModel(
                 headerTitle: "section_2",
                 headerHeight: 43,
                 cellViewModels: [
@@ -56,7 +56,7 @@ final class TableViewModelTests: XCTestCase {
         XCTAssertTrue(tableViewModel1.isEmpty)
 
         let tableViewModel2 = TableViewModel(
-            sectionModels: [TableViewSectionViewModel(
+            sectionModels: [TableSectionViewModel(
                 cellViewModels: []
             )]
         )
@@ -68,7 +68,7 @@ final class TableViewModelTests: XCTestCase {
     /// Table view sections can be successfully initialized
     /// using a plain section header.
     func testPlainHeaderFooterSectionModelInitalizer() {
-        let sectionModel = TableViewSectionViewModel(
+        let sectionModel = TableSectionViewModel(
             headerTitle: "foo",
             headerHeight: 42,
             cellViewModels: [generateTestCellViewModel()],
@@ -89,7 +89,7 @@ final class TableViewModelTests: XCTestCase {
     /// Table view sections can be successfully initialized
     /// using a custom section header type.
     func testCustomHeaderFooterSectionModelInitalizer() {
-        let sectionModel = TableViewSectionViewModel(
+        let sectionModel = TableSectionViewModel(
             cellViewModels: [generateTestCellViewModel()],
             headerViewModel: TestHeaderFooterViewModel(height: 42, viewKind: .header, label: "A"),
             footerViewModel: TestHeaderFooterViewModel(height: 43, viewKind: .footer, label: "A"),


### PR DESCRIPTION
- TableViewCellViewModel --> TableCellViewModel
- TableViewSectionHeaderFooterViewModel --> TableSectionHeaderFooterViewModel
- TableViewSectionViewModel --> TableSectionViewModel
