### PR TITLE
Check that the IndexPath is valid before using it

### DIFF
--- a/Sources/TableViewModel.swift
+++ b/Sources/TableViewModel.swift
@@ -105,7 +105,8 @@ public struct TableViewModel {
     }
 
     public subscript(indexPath: IndexPath) -> TableViewCellViewModel? {
-        guard let section = self[indexPath.section],
+        guard indexPath.count >= 2, // In rare cases, we've seen UIKit give us a bad IndexPath
+            let section = self[indexPath.section],
             let cellViewModels = section.cellViewModels, cellViewModels.count > indexPath.row else { return nil }
         return cellViewModels[ifExists: indexPath.row]
     }

--- a/Tests/TableView/TableViewModelTests.swift
+++ b/Tests/TableView/TableViewModelTests.swift
@@ -48,6 +48,7 @@ final class TableViewModelTests: XCTestCase {
         // Returns the section/cell model, if the index path exists within the table view model.
         XCTAssertEqual(tableViewModel[0]?.headerViewModel?.title, "section_1")
         XCTAssertEqual((tableViewModel[IndexPath(row: 0, section: 1)] as? TestCellViewModel)?.label, "A")
+        XCTAssertNil(tableViewModel[[] as IndexPath])
     }
 
     /// The `.isEmpty` property of the table view returns `true` when the table view


### PR DESCRIPTION
## Changes in this pull request

Issue fixed: A rare production issue where UIKit gives us a bad IndexPath.

### Checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have reviewed the [contributing guide](https://github.com/plangrid/ReactiveLists/blob/master/.github/CONTRIBUTING.md)