### PR TITLE
Allow selection of row animtions for table view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ The changelog for `ReactiveLists`. Also see the [releases](https://github.com/pl
 
 ------
 
+0.2.0
+-----
+
+- Allow selection of row animtions.
+
 0.1.0
 -----
 

--- a/Sources/TableViewDriver.swift
+++ b/Sources/TableViewDriver.swift
@@ -59,6 +59,20 @@ open class TableViewDriver: NSObject {
         }
     }
 
+    /// Animation for row insertions
+    public var insertionAnimation: UITableViewRowAnimation = .automatic {
+        didSet {
+            _tableViewDiffer?.insertionAnimation = insertionAnimation
+        }
+    }
+
+    /// Animation for row deletions
+    public var deletionAnimation: UITableViewRowAnimation = .automatic {
+        didSet {
+            _tableViewDiffer?.deletionAnimation = deletionAnimation
+        }
+    }
+
     /// If this property is set to `true`, updating the `tableViewModel` will always
     /// automatically lead to updating the UI state of the `UITableView`, even if cells/sections
     /// were moved/inserted/deleted.
@@ -176,6 +190,9 @@ open class TableViewDriver: NSObject {
                     tableView: self.tableView,
                     initialSectionedValues: newModel.diffingKeys
                 )
+
+                self._tableViewDiffer?.insertionAnimation = insertionAnimation
+                self._tableViewDiffer?.deletionAnimation = deletionAnimation
             } else if self._didReceiveFirstNonNilValue {
                 // If the current table view model is empty, default to an empty set of diffing keys
                 if let differ = self._tableViewDiffer {


### PR DESCRIPTION
## Changes in this pull request

Allows the selection of a different row animation. The `automatic` animation can look a bit odd sometimes. For example when inserting a section the cells come in from the left.

### Checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have reviewed the [contributing guide](https://github.com/plangrid/ReactiveLists/blob/master/.github/CONTRIBUTING.md)