### PR TITLE
[Fix] Make section and cell view models diffable by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ The changelog for `ReactiveLists`. Also see the [releases](https://github.com/pl
 
 ------
 
+0.1.2
+-----
+
+### Changed
+
+- Section and cell view models are now diffable by default. ([#119](https://github.com/plangrid/ReactiveLists/pull/119), [@jessesquires](https://github.com/jessesquires))
+Each provide default values for `diffingKey`, but you should be customize them for your own needs or opt-out of automatic diffing.
+    - `CollectionSectionViewModel` protocol now inherits from `DiffableViewModel` protocol
+    - `CollectionCellViewModel` protocol now inherits from `DiffableViewModel` protocol
+    - ` TableSectionViewModel` protocol now inherits from `DiffableViewModel` protocol
+    - `TableCellViewModel` protocol now inherits from `DiffableViewModel` protocol
+
 0.1.1
 -----
 
@@ -22,7 +34,7 @@ This release closes the [0.1.1 milestone](https://github.com/plangrid/ReactiveLi
 
 ### New
 
-- You can now customize the cell insertion and deletion animations on `TableViewDriver`. (#115, @wickwirew)
+- You can now customize the cell insertion and deletion animations on `TableViewDriver`. ([#115](https://github.com/plangrid/ReactiveLists/pull/115), [@wickwirew](https://github.com/wickwirew))
 - `ViewRegistrationInfo` properties `reuseIdentifier` and `registrationMethod` are now public
 - `ViewRegistrationInfo` now conforms to `Equatable`
 - `SupplementaryViewInfo` now conforms to `Equatable`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The changelog for `ReactiveLists`. Also see the [releases](https://github.com/pl
 ### Changed
 
 - Section and cell view models are now diffable by default. ([#119](https://github.com/plangrid/ReactiveLists/pull/119), [@jessesquires](https://github.com/jessesquires))
-Each provide default values for `diffingKey`, but you should be customize them for your own needs or opt-out of automatic diffing.
+Each provide default values for `diffingKey`, but you can customize them for your own needs or opt-out of automatic diffing.
     - `CollectionSectionViewModel` protocol now inherits from `DiffableViewModel` protocol
     - `CollectionCellViewModel` protocol now inherits from `DiffableViewModel` protocol
     - ` TableSectionViewModel` protocol now inherits from `DiffableViewModel` protocol

--- a/Sources/CollectionViewModel.swift
+++ b/Sources/CollectionViewModel.swift
@@ -18,7 +18,7 @@ import Dwifft
 import UIKit
 
 /// View model for the individual cells of a `UICollectionView`.
-public protocol CollectionCellViewModel: ReusableCellViewModelProtocol {
+public protocol CollectionCellViewModel: ReusableCellViewModelProtocol, DiffableViewModel {
 
     /// `CollectionViewDriver` will automatically apply an `accessibilityIdentifier` to the cell based on this format
     var accessibilityFormat: CellAccessibilityFormat { get }
@@ -110,27 +110,15 @@ public struct CollectionViewModel {
     var diffingKeys: SectionedValues<DiffingKey, DiffingKey> {
         return SectionedValues(
             self.sectionModels.map { section in
-                // Ensure we have a diffing key for the current section
-                guard let sectionDiffingKey = section.diffingKey else {
-                    fatalError("When diffing is enabled you need to provide a non-nil diffingKey for each section.")
-                }
-
-                // Ensure we have a diffing key for each cell in this section
-                let cellDiffingKeys: [DiffingKey] = section.cellViewModels.map { cell in
-                    guard let cell = cell as? DiffableViewModel else {
-                        fatalError("When diffing is enabled you need to provide cells which are DiffableViews.")
-                    }
-                    return "\(type(of: cell))_\(cell.diffingKey)"
-                }
-
-                return (sectionDiffingKey, cellDiffingKeys)
+                let cellDiffingKeys = section.cellViewModels.map { $0.diffingKey }
+                return (section.diffingKey, cellDiffingKeys)
             }
         )
     }
 }
 
 /// View model for a collection view section.
-public struct CollectionSectionViewModel {
+public struct CollectionSectionViewModel: DiffableViewModel {
 
     /// Cells to be shown in this section.
     let cellViewModels: [CollectionCellViewModel]
@@ -148,7 +136,7 @@ public struct CollectionSectionViewModel {
     /// For example:
     ///
     ///      public var diffingKey = { group.identifier }
-    public var diffingKey: String?
+    public var diffingKey: String
 
     /// Initializes a collection view section view model.
     ///
@@ -161,8 +149,7 @@ public struct CollectionSectionViewModel {
         cellViewModels: [CollectionCellViewModel],
         headerViewModel: CollectionSupplementaryViewModel? = nil,
         footerViewModel: CollectionSupplementaryViewModel? = nil,
-        diffingKey: String? = nil
-        ) {
+        diffingKey: String = UUID().uuidString) {
         self.cellViewModels = cellViewModels
         self.headerViewModel = headerViewModel
         self.footerViewModel = footerViewModel
@@ -190,14 +177,12 @@ extension CollectionSectionViewModel {
         cellViewModels: [CollectionCellViewModel],
         headerHeight: CGFloat? = nil,
         footerViewModel: CollectionSupplementaryViewModel? = nil,
-        diffingKey: String? = nil
-        ) {
+        diffingKey: String = UUID().uuidString) {
         self.init(
             cellViewModels: cellViewModels,
             headerViewModel: BlankSupplementaryViewModel(height: headerHeight),
             footerViewModel: footerViewModel,
-            diffingKey: diffingKey
-        )
+            diffingKey: diffingKey)
     }
 
     /// :nodoc:
@@ -205,14 +190,12 @@ extension CollectionSectionViewModel {
         cellViewModels: [CollectionCellViewModel],
         headerViewModel: CollectionSupplementaryViewModel? = nil,
         footerHeight: CGFloat? = nil,
-        diffingKey: String? = nil
-        ) {
+        diffingKey: String = UUID().uuidString) {
         self.init(
             cellViewModels: cellViewModels,
             headerViewModel: headerViewModel,
             footerViewModel: BlankSupplementaryViewModel(height: footerHeight),
-            diffingKey: diffingKey
-        )
+            diffingKey: diffingKey)
     }
 
     /// :nodoc:
@@ -220,13 +203,11 @@ extension CollectionSectionViewModel {
         cellViewModels: [CollectionCellViewModel],
         headerHeight: CGFloat? = nil,
         footerHeight: CGFloat? = nil,
-        diffingKey: String? = nil
-        ) {
+        diffingKey: String = UUID().uuidString) {
         self.init(
             cellViewModels: cellViewModels,
             headerViewModel: BlankSupplementaryViewModel(height: headerHeight),
             footerViewModel: BlankSupplementaryViewModel(height: footerHeight),
-            diffingKey: diffingKey
-        )
+            diffingKey: diffingKey)
     }
 }


### PR DESCRIPTION
- Section and cell view models are now diffable by default.
They have default values for `diffingKey`, but clients should be customizing these for their needs.
    - `CollectionSectionViewModel` protocol now inherits from `DiffableViewModel` protocol
    - `CollectionCellViewModel` protocol now inherits from `DiffableViewModel` protocol
    - ` TableSectionViewModel` protocol now inherits from `DiffableViewModel` protocol
    - `TableCellViewModel` protocol now inherits from `DiffableViewModel` protocol

Closes #114
