### PR TITLE
Remove TableSectionViewModel.collapsed, close #120

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,12 @@ The changelog for `ReactiveLists`. Also see the [releases](https://github.com/pl
 
 ------
 
-0.1.2
+0.1.2 (NEXT RELEASE)
 -----
+
+### Breaking
+
+- Removed `TableSectionViewModel.collapsed` ([#120](https://github.com/plangrid/ReactiveLists/pull/120), [@jessesquires](https://github.com/jessesquires))
 
 ### Changed
 

--- a/Sources/TableViewDriver.swift
+++ b/Sources/TableViewDriver.swift
@@ -231,7 +231,7 @@ extension TableViewDriver: UITableViewDataSource {
 
     /// :nodoc:
     public func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        guard let sectionModel = self.tableViewModel?[section], !sectionModel.collapsed else { return 0 }
+        guard let sectionModel = self.tableViewModel?[section] else { return 0 }
         return sectionModel.cellViewModels.count
     }
 

--- a/Sources/TableViewModel.swift
+++ b/Sources/TableViewModel.swift
@@ -125,9 +125,6 @@ public struct TableSectionViewModel: DiffableViewModel {
     /// View model for the footer of this section.
     public let footerViewModel: TableSectionHeaderFooterViewModel?
 
-    /// Indicates whether or not this section is collapsed.
-    public var collapsed: Bool = false
-
     /// The key used by the diffing algorithm to uniquely identify this section.
     /// If you are using automatic diffing on the `TableViewDriver` (which is enabled by default)
     /// you are required to provide a key that uniquely identifies this section.
@@ -149,18 +146,15 @@ public struct TableSectionViewModel: DiffableViewModel {
     ///   - cellViewModels: The cell view models contained in this section.
     ///   - headerViewModel: A header view model for this section (defaults to `nil`).
     ///   - footerViewModel: A footer view model for this section (defaults to `nil`).
-    ///   - collapsed: Whether or not this section is collapsed (defaults to `false`).
     ///   - diffingKey: A diffing key.
     public init(
         cellViewModels: [TableCellViewModel],
         headerViewModel: TableSectionHeaderFooterViewModel? = nil,
         footerViewModel: TableSectionHeaderFooterViewModel? = nil,
-        collapsed: Bool = false,
         diffingKey: String = UUID().uuidString) {
         self.cellViewModels = cellViewModels
         self.headerViewModel = headerViewModel
         self.footerViewModel = footerViewModel
-        self.collapsed = collapsed
         self.diffingKey = diffingKey
     }
 

--- a/Tests/TableView/TableViewDriverTests.swift
+++ b/Tests/TableView/TableViewDriverTests.swift
@@ -38,29 +38,24 @@ final class TableViewDriverTests: XCTestCase {
             TableSectionViewModel(
                 cellViewModels: [],
                 headerViewModel: TestHeaderFooterViewModel(height: 10, viewKind: .header, label: "A"),
-                footerViewModel: TestHeaderFooterViewModel(height: 11, viewKind: .footer, label: "A"),
-                collapsed: false),
+                footerViewModel: TestHeaderFooterViewModel(height: 11, viewKind: .footer, label: "A")),
             TableSectionViewModel(
                 cellViewModels: ["A", "B", "C"].map { _generateTestCellViewModel($0) },
                 headerViewModel: nil,
-                footerViewModel: TestHeaderFooterViewModel(title: "footer_2", height: 21),
-                collapsed: false),
+                footerViewModel: TestHeaderFooterViewModel(title: "footer_2", height: 21)),
              TableSectionViewModel(
                 cellViewModels: ["D", "E", "F"].map { _generateTestCellViewModel($0) },
                 headerViewModel: TestHeaderFooterViewModel(title: "header_3", height: 30),
-                footerViewModel: nil,
-                collapsed: true),
+                footerViewModel: nil),
             ], sectionIndexTitles: ["A", "Z", "Z"])
         self._tableViewDataSource = TableViewDriver(
             tableView: tableView,
-            automaticDiffingEnabled: false
-        )
+            automaticDiffingEnabled: false)
         self._tableViewDataSource.tableViewModel = self._tableViewModel
     }
 
     /// Table view sections described in the table view model are converted into views correctly.
     func testTableViewSections() {
-
         XCTAssertEqual(self._tableViewDataSource.sectionIndexTitles(for: self._tableView)!, ["A", "Z", "Z"])
 
         XCTAssertEqual(self._tableViewDataSource.numberOfSections(in: self._tableView), 3)
@@ -81,7 +76,7 @@ final class TableViewDriverTests: XCTestCase {
             XCTAssertEqual(self._tableViewDataSource.tableView(self._tableView, titleForFooterInSection: $0), $1)
         }
 
-        parameterize(cases: (0, 0), (1, 3), (2, 0), (9, 0)) {
+        parameterize(cases: (0, 0), (1, 3), (2, 3), (9, 0)) {
             XCTAssertEqual(self._tableViewDataSource.tableView(self._tableView, numberOfRowsInSection: $0), $1)
         }
     }

--- a/Tests/TableView/TableViewModelTests.swift
+++ b/Tests/TableView/TableViewModelTests.swift
@@ -80,7 +80,6 @@ final class TableViewModelTests: XCTestCase {
         XCTAssertEqual(sectionModel.cellViewModels.count, 1)
         XCTAssertEqual(sectionModel.headerViewModel?.height, 42)
         XCTAssertEqual(sectionModel.footerViewModel?.height, 43)
-        XCTAssertFalse(sectionModel.collapsed)
         XCTAssertEqual(sectionModel.headerViewModel?.title, "foo")
         XCTAssertEqual(sectionModel.footerViewModel?.title, "bar")
         XCTAssertNil(sectionModel.headerViewModel?.viewInfo)
@@ -93,9 +92,7 @@ final class TableViewModelTests: XCTestCase {
         let sectionModel = TableSectionViewModel(
             cellViewModels: [generateTestCellViewModel()],
             headerViewModel: TestHeaderFooterViewModel(height: 42, viewKind: .header, label: "A"),
-            footerViewModel: TestHeaderFooterViewModel(height: 43, viewKind: .footer, label: "A"),
-            collapsed: true
-        )
+            footerViewModel: TestHeaderFooterViewModel(height: 43, viewKind: .footer, label: "A"))
 
         XCTAssertEqual(sectionModel.cellViewModels.count, 1)
         XCTAssertEqual(sectionModel.headerViewModel?.height, 42)
@@ -106,7 +103,6 @@ final class TableViewModelTests: XCTestCase {
         let headerInfo = sectionModel.headerViewModel?.viewInfo
         let footerInfo = sectionModel.footerViewModel?.viewInfo
 
-        XCTAssertTrue(sectionModel.collapsed)
         XCTAssertTrue(headerInfo?.registrationInfo.registrationMethod == .fromClass(HeaderView.self))
         XCTAssertTrue(footerInfo?.registrationInfo.registrationMethod == .fromClass(FooterView.self))
         XCTAssertEqual(headerInfo?.registrationInfo.reuseIdentifier, "HeaderView")
@@ -120,5 +116,4 @@ final class TableViewModelTests: XCTestCase {
             "access_footer+44"
         )
     }
-
 }


### PR DESCRIPTION
This is seems to be a vestigial aspect of the framework from early PlanGrid days.

We don't use this anywhere in PlanGrid.

To achieve this sort of "collapsing" behavior, you'd capture this state elsewhere in your model, and simply regenerate your SectionModel with zero CellViewModels.

This is how we currently do this in PlanGrid.

And, I think this makes more sense to generate full state changes, rather than "hiding" a section. (i.e., this is sort of a hack)

Further, this is complicates notions of "empty/nil state" (see #48 and IP-3275) and I want to remove that complexity.

Closes #120