### PR TITLE
Fix isEmpty calculations, add property to collection models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,19 @@ The changelog for `ReactiveLists`. Also see the [releases](https://github.com/pl
 
 ### Breaking
 
-- Removed `TableSectionViewModel.collapsed` ([#120](https://github.com/plangrid/ReactiveLists/pull/120), [@jessesquires](https://github.com/jessesquires))
+- Removed `TableSectionViewModel.collapsed` ([#121](https://github.com/plangrid/ReactiveLists/pull/121), [@jessesquires](https://github.com/jessesquires))
+
+- Removed undocumented initializers for `CollectionSectionViewModel` (the ones that received `headerHeight:` and/or `footerHeight:`) ([#123](https://github.com/plangrid/ReactiveLists/pull/123), [@jessesquires](https://github.com/jessesquires))
+
+### Fixed
+
+- Fixed incorrect calculation for `TableViewModel.isEmpty`. It now correctly returns true only if all sections return `true` for `isEmpty`. ([#123](https://github.com/plangrid/ReactiveLists/pull/123), [@jessesquires](https://github.com/jessesquires))
+
+### New
+
+- Added `CollectionSectionViewModel.isEmpty` property ([#123](https://github.com/plangrid/ReactiveLists/pull/123), [@jessesquires](https://github.com/jessesquires))
+
+- Added `CollectionViewModel.isEmpty` property ([#123](https://github.com/plangrid/ReactiveLists/pull/123), [@jessesquires](https://github.com/jessesquires))
 
 ### Changed
 

--- a/Example/CollectionViewController.swift
+++ b/Example/CollectionViewController.swift
@@ -79,7 +79,7 @@ extension CollectionViewController {
                     accessibilityFormat: "CollectionViewHeaderView"
                 )
             )
-            return CollectionSectionViewModel(cellViewModels: cellViewModels, headerViewModel: headerViewModel, footerHeight: nil, diffingKey: group.name)
+            return CollectionSectionViewModel(cellViewModels: cellViewModels, headerViewModel: headerViewModel, diffingKey: group.name)
         }
         return CollectionViewModel(sectionModels: sections)
     }

--- a/Sources/CollectionViewModel.swift
+++ b/Sources/CollectionViewModel.swift
@@ -82,6 +82,11 @@ public struct CollectionViewModel {
     /// The section view models for this collection view.
     public let sectionModels: [CollectionSectionViewModel]
 
+    /// Returns `true` if this collection has all empty sections.
+    public var isEmpty: Bool {
+        return self.sectionModels.first(where: { !$0.isEmpty }) == nil
+    }
+
     /// Initializes a collection view model with the sections provided.
     ///
     /// - Parameter sectionModels: the sections that need to be shown in this collection view.
@@ -122,6 +127,7 @@ public struct CollectionSectionViewModel: DiffableViewModel {
 
     /// Cells to be shown in this section.
     let cellViewModels: [CollectionCellViewModel]
+
     /// View model for the header of this section.
     let headerViewModel: CollectionSupplementaryViewModel?
 
@@ -137,6 +143,11 @@ public struct CollectionSectionViewModel: DiffableViewModel {
     ///
     ///      public var diffingKey = { group.identifier }
     public var diffingKey: String
+
+    /// Returns `true` if this section has zero cell view models, `false` otherwise.
+    public var isEmpty: Bool {
+        return self.cellViewModels.isEmpty
+    }
 
     /// Initializes a collection view section view model.
     ///
@@ -154,60 +165,5 @@ public struct CollectionSectionViewModel: DiffableViewModel {
         self.headerViewModel = headerViewModel
         self.footerViewModel = footerViewModel
         self.diffingKey = diffingKey
-    }
-
-    private struct BlankSupplementaryViewModel: CollectionSupplementaryViewModel {
-        let height: CGFloat?
-        let viewInfo: SupplementaryViewInfo? = nil
-
-        func applyViewModelToView(_ view: UICollectionReusableView) { }
-    }
-}
-
-// MARK: Initializers without header/footer view models
-
-// Note: All initializers in this extension are undocumented, because we intend
-// to remove them. We want to get rid of the legacy functionality that creates
-// blank headers & footers instead of using spacing properties available via
-// `UICollectionViewLayout`s.
-extension CollectionSectionViewModel {
-
-    /// :nodoc:
-    public init(
-        cellViewModels: [CollectionCellViewModel],
-        headerHeight: CGFloat? = nil,
-        footerViewModel: CollectionSupplementaryViewModel? = nil,
-        diffingKey: String = UUID().uuidString) {
-        self.init(
-            cellViewModels: cellViewModels,
-            headerViewModel: BlankSupplementaryViewModel(height: headerHeight),
-            footerViewModel: footerViewModel,
-            diffingKey: diffingKey)
-    }
-
-    /// :nodoc:
-    public init(
-        cellViewModels: [CollectionCellViewModel],
-        headerViewModel: CollectionSupplementaryViewModel? = nil,
-        footerHeight: CGFloat? = nil,
-        diffingKey: String = UUID().uuidString) {
-        self.init(
-            cellViewModels: cellViewModels,
-            headerViewModel: headerViewModel,
-            footerViewModel: BlankSupplementaryViewModel(height: footerHeight),
-            diffingKey: diffingKey)
-    }
-
-    /// :nodoc:
-    public init(
-        cellViewModels: [CollectionCellViewModel],
-        headerHeight: CGFloat? = nil,
-        footerHeight: CGFloat? = nil,
-        diffingKey: String = UUID().uuidString) {
-        self.init(
-            cellViewModels: cellViewModels,
-            headerViewModel: BlankSupplementaryViewModel(height: headerHeight),
-            footerViewModel: BlankSupplementaryViewModel(height: footerHeight),
-            diffingKey: diffingKey)
     }
 }

--- a/Sources/TableViewModel.swift
+++ b/Sources/TableViewModel.swift
@@ -135,7 +135,7 @@ public struct TableSectionViewModel: DiffableViewModel {
     ///      public var diffingKey = { group.identifier }
     public var diffingKey: String
 
-    /// Returns `true` is the section is empty, `false` otherwise.
+    /// Returns `true` if this section has zero cell view models, `false` otherwise.
     public var isEmpty: Bool {
         return self.cellViewModels.isEmpty
     }
@@ -190,12 +190,9 @@ public struct TableViewModel {
     /// The section view models for this table view.
     public let sectionModels: [TableSectionViewModel]
 
-    /// Returns `true` if this table has no sections or has a single empty section.
+    /// Returns `true` if this table has all empty sections.
     public var isEmpty: Bool {
-        if self.sectionModels.count == 1 {
-            return self.sectionModels.first!.isEmpty
-        }
-        return self.sectionModels.isEmpty
+        return self.sectionModels.first(where: { !$0.isEmpty }) == nil
     }
 
     /// Initializes a table view model with one section and the cell models provided

--- a/Tests/CollectionView/CollectionViewDriverDiffingTests.swift
+++ b/Tests/CollectionView/CollectionViewDriverDiffingTests.swift
@@ -45,8 +45,6 @@ final class CollectionViewDriverDiffingTests: XCTestCase {
             sectionModels: [
                 CollectionSectionViewModel(
                     cellViewModels: [],
-                    headerHeight: 44,
-                    footerHeight: 44,
                     diffingKey: "1"
                 )
             ]
@@ -58,8 +56,6 @@ final class CollectionViewDriverDiffingTests: XCTestCase {
             sectionModels: [
                 CollectionSectionViewModel(
                     cellViewModels: [CollectionUserCellModel(user: User(name: "Mona"))],
-                    headerHeight: 44,
-                    footerHeight: 44,
                     diffingKey: "1"
                 )
             ]
@@ -85,14 +81,10 @@ final class CollectionViewDriverDiffingTests: XCTestCase {
             sectionModels: [
                 CollectionSectionViewModel(
                     cellViewModels: [],
-                    headerHeight: 44,
-                    footerHeight: 44,
                     diffingKey: "1"
                 ),
                 CollectionSectionViewModel(
                     cellViewModels: [],
-                    headerHeight: 44,
-                    footerHeight: 44,
                     diffingKey: "2"
                 )
             ]
@@ -104,8 +96,6 @@ final class CollectionViewDriverDiffingTests: XCTestCase {
             sectionModels: [
                 CollectionSectionViewModel(
                     cellViewModels: [],
-                    headerHeight: 44,
-                    footerHeight: 44,
                     diffingKey: "2"
                 )
             ]

--- a/Tests/CollectionView/CollectionViewModelTests.swift
+++ b/Tests/CollectionView/CollectionViewModelTests.swift
@@ -19,75 +19,6 @@ import XCTest
 
 final class CollectionViewModelTests: XCTestCase {
 
-    /// Can be initialized by specifying a header and footer height,
-    /// without specifying a header and footer view, wich results
-    /// in a blank default view being used.
-    func testViewModelInitalizerWithBlankHeaderAndFooter() {
-        let sectionModel = CollectionSectionViewModel(
-            cellViewModels: [generateTestCollectionCellViewModel()],
-            headerHeight: 40,
-            footerHeight: 50
-        )
-
-        XCTAssertEqual(sectionModel.cellViewModels.count, 1)
-        XCTAssertEqual(sectionModel.headerViewModel?.height, 40)
-        XCTAssertEqual(sectionModel.footerViewModel?.height, 50)
-        XCTAssertNil(sectionModel.headerViewModel?.viewInfo)
-        XCTAssertNil(sectionModel.footerViewModel?.viewInfo)
-    }
-
-    /// Can be initialized by specifying a header height,
-    /// without specifying a header view, wich results
-    /// in a blank default view being used.
-    func testViewModelInitializerWithBlankHeader() {
-        let sectionModel = CollectionSectionViewModel(
-            cellViewModels: [generateTestCollectionCellViewModel()],
-            headerHeight: 40,
-            footerViewModel: TestCollectionViewSupplementaryViewModel(
-                height: 50,
-                viewKind: .footer,
-                sectionLabel: "A"
-            )
-        )
-
-        XCTAssertEqual(sectionModel.cellViewModels.count, 1)
-        XCTAssertNil(sectionModel.headerViewModel?.viewInfo)
-
-        XCTAssertEqual(sectionModel.headerViewModel?.height, 40)
-        XCTAssertEqual(sectionModel.footerViewModel?.height, 50)
-
-        let viewInfo = sectionModel.footerViewModel?.viewInfo
-        XCTAssertTrue(viewInfo?.registrationInfo.registrationMethod == .fromClass(FooterView.self))
-        XCTAssertEqual(viewInfo?.registrationInfo.reuseIdentifier, "FooterView")
-        XCTAssertEqual(viewInfo?.accessibilityFormat.accessibilityIdentifierForSection(84), "access_footer+84")
-    }
-
-    /// Can be initialized by specifying a footer height,
-    /// without specifying a footer view, wich results
-    /// in a blank default view being used.
-    func testViewModelInitializerWithBlankFooter() {
-        let sectionModel = CollectionSectionViewModel(
-            cellViewModels: [generateTestCollectionCellViewModel()],
-            headerViewModel: TestCollectionViewSupplementaryViewModel(
-                height: 40,
-                viewKind: .header,
-                sectionLabel: "A"
-            ),
-            footerHeight: 50
-        )
-
-        XCTAssertEqual(sectionModel.cellViewModels.count, 1)
-        XCTAssertNil(sectionModel.footerViewModel?.viewInfo)
-
-        XCTAssertEqual(sectionModel.headerViewModel?.height, 40)
-        XCTAssertEqual(sectionModel.footerViewModel?.height, 50)
-
-        let viewInfo = sectionModel.headerViewModel?.viewInfo
-        XCTAssertTrue(viewInfo?.registrationInfo.registrationMethod == .fromClass(HeaderView.self))
-        XCTAssertEqual(viewInfo?.registrationInfo.reuseIdentifier, "HeaderView")
-        XCTAssertEqual(viewInfo?.accessibilityFormat.accessibilityIdentifierForSection(84), "access_header+84")
-    }
-
     /// Can be initialized with a custom header and footer view.
     func testViewModelInitializerWithCustomHeaderAndFooter() {
         let sectionModel = CollectionSectionViewModel(
@@ -125,18 +56,13 @@ final class CollectionViewModelTests: XCTestCase {
     /// model returns `nil`.
     func testSubscripts() {
         let collectionViewModel = CollectionViewModel(sectionModels: [
-            CollectionSectionViewModel(
-                cellViewModels: [],
-                headerHeight: 42,
-                footerHeight: nil),
+            CollectionSectionViewModel(cellViewModels: []),
             CollectionSectionViewModel(
                 cellViewModels: [
                     generateTestCollectionCellViewModel("A"),
                     generateTestCollectionCellViewModel("B"),
                     generateTestCollectionCellViewModel("C"),
-                ],
-                headerHeight: 43,
-                footerHeight: nil),
+                ]),
         ])
 
         // Returns `nil` when there's no cell/section at the provided path.
@@ -146,9 +72,30 @@ final class CollectionViewModelTests: XCTestCase {
         XCTAssertNil(collectionViewModel[IndexPath(row: 9, section: 1)])
 
         // Returns the section/cell model, if the index path exists within the table view model.
-        XCTAssertEqual(collectionViewModel[0]?.headerViewModel?.height, 42)
         let cell_row_0_section_1 = collectionViewModel[IndexPath(row: 0, section: 1)]
             as? TestCollectionCellViewModel
         XCTAssertEqual(cell_row_0_section_1?.label, "A")
+    }
+
+    /// The `.isEmpty` property of the collection view.
+    func testIsEmpty() {
+        let section0 = CollectionSectionViewModel(cellViewModels: generateCollectionCellViewModels())
+        let sectionEmpty = CollectionSectionViewModel(cellViewModels: [])
+        let section2 = CollectionSectionViewModel(cellViewModels: generateCollectionCellViewModels(count: 1))
+
+        let viewModel1 = CollectionViewModel(sectionModels: [])
+        XCTAssertTrue(viewModel1.isEmpty)
+
+        let viewModel2 = CollectionViewModel(sectionModels: [sectionEmpty, sectionEmpty, sectionEmpty, sectionEmpty])
+        XCTAssertTrue(viewModel2.isEmpty)
+
+        let viewModel3 = CollectionViewModel(sectionModels: [sectionEmpty, section0, section0, section0])
+        XCTAssertFalse(viewModel3.isEmpty)
+
+        let viewModel4 = CollectionViewModel(sectionModels: [section2, section0, section0, sectionEmpty])
+        XCTAssertFalse(viewModel4.isEmpty)
+
+        let viewModel5 = CollectionViewModel(sectionModels: [section0, sectionEmpty, section2])
+        XCTAssertFalse(viewModel5.isEmpty)
     }
 }

--- a/Tests/Fixtures/TestCollectionViewModels.swift
+++ b/Tests/Fixtures/TestCollectionViewModels.swift
@@ -88,9 +88,18 @@ class TestCollectionReusableView: UICollectionReusableView {
 }
 
 func generateTestCollectionCellViewModel(_ label: String? = nil) -> TestCollectionCellViewModel {
-    return TestCollectionCellViewModel(
-        label: label ?? UUID().uuidString,
-        didSelect: nil,
-        didDeselect: nil
+    return TestCollectionCellViewModel(label: label ?? UUID().uuidString,
+                                       didSelect: nil,
+                                       didDeselect: nil
     )
+}
+
+func generateCollectionCellViewModels(count: Int = 4) -> [CollectionCellViewModel] {
+    var models = [TestCollectionCellViewModel]()
+    for _ in 0..<count {
+        models.append(TestCollectionCellViewModel(label: UUID().uuidString,
+                                                  didSelect: nil,
+                                                  didDeselect: nil))
+    }
+    return models
 }

--- a/Tests/Fixtures/TestTableViewModels.swift
+++ b/Tests/Fixtures/TestTableViewModels.swift
@@ -23,8 +23,8 @@ struct TestCellViewModel: TableCellViewModel {
     let shouldHighlight = false
     let shouldIndentWhileEditing = false
     let accessibilityFormat: CellAccessibilityFormat = "access-%{section}.%{row}"
+    let registrationInfo = ViewRegistrationInfo(classType: TestTableViewCell.self)
 
-    let registrationInfo: ViewRegistrationInfo
     let label: String
     var willBeginEditing: WillBeginEditingClosure?
     var didEndEditing: DidEndEditingClosure?
@@ -32,13 +32,11 @@ struct TestCellViewModel: TableCellViewModel {
     var didSelectClosure: DidSelectClosure?
 
     init(label: String,
-         registrationInfo: ViewRegistrationInfo,
          willBeginEditing: WillBeginEditingClosure? = nil,
          didEndEditing: DidEndEditingClosure? = nil,
          commitEditingStyle: CommitEditingStyleClosure? = nil,
          didSelectClosure: DidSelectClosure? = nil
     ) {
-        self.registrationInfo = registrationInfo
         self.label = label
         self.willBeginEditing = willBeginEditing
         self.didEndEditing = didEndEditing
@@ -70,14 +68,16 @@ func path(_ section: Int, _ row: Int = 0) -> IndexPath {
     return IndexPath(row: row, section: section)
 }
 
+func generateTableCellViewModels(count: Int = 4) -> [TableCellViewModel] {
+    var models = [TestCellViewModel]()
+    for _ in 0..<count {
+        models.append(TestCellViewModel(label: UUID().uuidString))
+    }
+    return models
+}
+
 func generateTestCellViewModel(_ label: String? = nil) -> TestCellViewModel {
-    return TestCellViewModel(label: label ?? UUID().uuidString,
-                             registrationInfo: ViewRegistrationInfo(classType: TestTableViewCell.self),
-                             willBeginEditing: nil,
-                             didEndEditing: nil,
-                             commitEditingStyle: nil,
-                             didSelectClosure: nil
-    )
+    return TestCellViewModel(label: label ?? UUID().uuidString)
 }
 
 struct TestHeaderFooterViewModel: TableSectionHeaderFooterViewModel {

--- a/Tests/TableView/TableViewDriverTests.swift
+++ b/Tests/TableView/TableViewDriverTests.swift
@@ -277,7 +277,7 @@ final class TableViewDriverTests: XCTestCase {
 // MARK: Test data generation
 
 private func _generateTestCellViewModel(_ label: String) -> TestCellViewModel {
-    return TestCellViewModel(label: label, registrationInfo: ViewRegistrationInfo(classType: UITableViewCell.self))
+    return TestCellViewModel(label: label)
 }
 
 private func _generateTestTableViewModelForRefreshingViews() -> TableViewModel {

--- a/Tests/TableView/TableViewModelTests.swift
+++ b/Tests/TableView/TableViewModelTests.swift
@@ -50,20 +50,29 @@ final class TableViewModelTests: XCTestCase {
         XCTAssertNil(tableViewModel[[] as IndexPath])
     }
 
-    /// The `.isEmpty` property of the table view returns `true` when the table view
-    /// contains no sections or one section with no cells.
+    /// The `.isEmpty` property of the table view.
     func testIsEmpty() {
+        let section0 = TableSectionViewModel(cellViewModels: generateTableCellViewModels())
+        let sectionEmpty = TableSectionViewModel(cellViewModels: [])
+        let section2 = TableSectionViewModel(cellViewModels: generateTableCellViewModels(count: 1))
+
         let tableViewModel1 = TableViewModel(sectionModels: [])
         XCTAssertTrue(tableViewModel1.isEmpty)
 
-        let tableViewModel2 = TableViewModel(
-            sectionModels: [TableSectionViewModel(
-                cellViewModels: []
-            )]
-        )
-
-        XCTAssertTrue(tableViewModel1.isEmpty)
+        let tableViewModel2 = TableViewModel(cellViewModels: [])
         XCTAssertTrue(tableViewModel2.isEmpty)
+
+        let tableViewModel3 = TableViewModel(sectionModels: [sectionEmpty, sectionEmpty, sectionEmpty, sectionEmpty])
+        XCTAssertTrue(tableViewModel3.isEmpty)
+
+        let tableViewModel4 = TableViewModel(sectionModels: [sectionEmpty, section0, section0, section0])
+        XCTAssertFalse(tableViewModel4.isEmpty)
+
+        let tableViewModel5 = TableViewModel(sectionModels: [section2, section0, section0, sectionEmpty])
+        XCTAssertFalse(tableViewModel5.isEmpty)
+
+        let tableViewModel6 = TableViewModel(sectionModels: [section0, sectionEmpty, section2])
+        XCTAssertFalse(tableViewModel6.isEmpty)
     }
 
     /// Table view sections can be successfully initialized


### PR DESCRIPTION
- Fix `TableViewModel.isEmpty` calculation
- Add `CollectionSectionViewModel.isEmpty`
- Add `CollectionViewModel.isEmpty`
- Remove undocumented initializers for `CollectionSectionViewModel` (the ones that received `headerHeight:` and/or `footerHeight:`)
These were causing ambiguous naming errors. Also, we don't use them in PlanGrid.

Closes #48
