### PR TITLE
reloadData if diffing before refreshViews if diffing is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ The changelog for `ReactiveLists`. Also see the [releases](https://github.com/pl
 
 ------
 
+0.1.1-patch1
+-----
+
+### Fixed
+
+- Fix edge case reloading bug when reloading a table view with diffing disabled
+
 0.1.1
 -----
 

--- a/Sources/TableViewDriver.swift
+++ b/Sources/TableViewDriver.swift
@@ -197,6 +197,7 @@ open class TableViewDriver: NSObject {
                 }
             }
         } else {
+            self.tableView.reloadData()
             self.refreshViews()
         }
     }

--- a/Sources/TableViewDriver.swift
+++ b/Sources/TableViewDriver.swift
@@ -197,6 +197,9 @@ open class TableViewDriver: NSObject {
                 }
             }
         } else {
+            // We need to call reloadData here to ensure UITableView is in-sync with the data source before we start
+            // making calls to access visible cells. In the automatic diffing case, this is handled by calls to
+            // beginUpdates() endUpdates()
             self.tableView.reloadData()
             self.refreshViews()
         }


### PR DESCRIPTION
## Changes in this pull request

This calls `reloadData` on `self.tableView` when diffing is disabled. This ensures that the `UITableView` is in sync with new data model before attempting to call methods on `UITableView` that would require the data model to be in sync to get correct results (i.e. `cellForRow(at:)`). This prevents crashing in `cellForRow(at:)` when `UITableView` asks for cells near a user-requested (programmatically), when the data model may not actually have the data for that cell.

### Checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have reviewed the [contributing guide](https://github.com/plangrid/ReactiveLists/blob/master/.github/CONTRIBUTING.md)