### PR TITLE
Refactor table view updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ The changelog for `ReactiveLists`. Also see the [releases](https://github.com/pl
 This release closes the [0.2.0 milestone](https://github.com/plangrid/ReactiveLists/milestone/2).
 
 
+### Breaking
+- `TableViewDriver.refreshViews(refreshContext:)` (and the related enum) is no longer `public`. This is no longer needed, now that setting `tableViewModel` has been improved in the non-diffing case. ([#130](https://github.com/plangrid/ReactiveLists/pull/130), [@benasher44](https://github.com/benasher44))
+
+### Fixed
+
+- Setting `tableViewModel` now always reloads the `UITableView`'s datasource ([#130](https://github.com/plangrid/ReactiveLists/pull/130), [@benasher44](https://github.com/benasher44))
+
 0.1.2
 -----
 


### PR DESCRIPTION
## Changes in this pull request

This cleans up table view updates to no longer manually update cells and headers. All updates to the model now reload the table datasource. With diffing enabled, behavior is the same. This mainly improves behavior with diffing disabled: non-diffing updates can now tell if a full `reloadData` is necessary or if `beginUpdates/endUpdates` can be used fo the model update.

This change is covered by existing tests.

### Checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have reviewed the [contributing guide](https://github.com/plangrid/ReactiveLists/blob/master/.github/CONTRIBUTING.md)