### PR TITLE
Add ifExists: to subscripts that return optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,19 @@ The changelog for `ReactiveLists`. Also see the [releases](https://github.com/pl
 
 ------
 
-0.2.0 (NEXT)
-------------
+0.2.0
+-----
 
 This release closes the [0.2.0 milestone](https://github.com/plangrid/ReactiveLists/milestone/2).
+
+0.1.3 (NEXT)
+------------
+
+This release closes the [0.1.3 milestone](https://github.com/plangrid/ReactiveLists/milestone/6).
+
+### Breaking
+
+- Changes `TableViewModel.subscript` and `CollectionViewModel.subscript` methods that return an `Optional` by adding the `ifExists:` parameter name (separating them from future non-`Optional` `Collection` subscripts) ([#131](https://github.com/plangrid/ReactiveLists/pull/131), [@jessesquires](https://github.com/benasher44))
 
 
 0.1.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ This release closes the [0.1.3 milestone](https://github.com/plangrid/ReactiveLi
 
 ### Breaking
 
-- Changes `TableViewModel.subscript` and `CollectionViewModel.subscript` methods that return an `Optional` by adding the `ifExists:` parameter name (separating them from future non-`Optional` `Collection` subscripts) ([#131](https://github.com/plangrid/ReactiveLists/pull/131), [@jessesquires](https://github.com/benasher44))
+- Changes `TableViewModel.subscript` and `CollectionViewModel.subscript` methods that return an `Optional` by adding the `ifExists:` parameter name (separating them from future non-`Optional` `Collection` subscripts) ([#131](https://github.com/plangrid/ReactiveLists/pull/131), [@benasher44](https://github.com/benasher44))
 
 
 0.1.2

--- a/Sources/CollectionViewDriver.swift
+++ b/Sources/CollectionViewDriver.swift
@@ -95,7 +95,7 @@ public class CollectionViewDriver: NSObject {
 
         let visibleIndexPathsForItems = self.collectionView.indexPathsForVisibleItems
         for indexPath in visibleIndexPathsForItems {
-            guard let model = self.collectionViewModel?[indexPath] else { continue }
+            guard let model = self.collectionViewModel?[ifExists: indexPath] else { continue }
             guard let cell = self.collectionView.cellForItem(at: indexPath) else { continue }
             model.applyViewModelToCell(cell)
             cell.accessibilityIdentifier = model.accessibilityFormat.accessibilityIdentifierForIndexPath(indexPath)
@@ -103,7 +103,7 @@ public class CollectionViewDriver: NSObject {
 
         let visibleIndexPathsForHeaders = self.collectionView.indexPathsForVisibleSupplementaryElements(ofKind: UICollectionElementKindSectionHeader)
         for indexPath in visibleIndexPathsForHeaders {
-            guard let headerModel = self.collectionViewModel?[indexPath.section]?.headerViewModel else {
+            guard let headerModel = self.collectionViewModel?[ifExists: indexPath.section]?.headerViewModel else {
                 continue
             }
             guard let headerView = self.collectionView.supplementaryView(forElementKind: UICollectionElementKindSectionHeader, at: indexPath) else {
@@ -115,7 +115,7 @@ public class CollectionViewDriver: NSObject {
 
         let visibleIndexPathsForFooters = self.collectionView.indexPathsForVisibleSupplementaryElements(ofKind: UICollectionElementKindSectionFooter)
         for indexPath in visibleIndexPathsForFooters {
-            guard let footerModel = self.collectionViewModel?[indexPath.section]?.footerViewModel else {
+            guard let footerModel = self.collectionViewModel?[ifExists: indexPath.section]?.footerViewModel else {
                 continue
             }
             guard let footerView = self.collectionView.supplementaryView(forElementKind: UICollectionElementKindSectionFooter, at: indexPath) else {
@@ -174,7 +174,7 @@ public class CollectionViewDriver: NSObject {
     }
 
     private func _sizeForSupplementaryViewOfKind(_ elementKind: SupplementaryViewKind, inSection section: Int, collectionViewLayout: UICollectionViewLayout) -> CGSize {
-        guard let sectionModel = self.collectionViewModel?[section] else { return CGSize.zero }
+        guard let sectionModel = self.collectionViewModel?[ifExists: section] else { return CGSize.zero }
         let isHeader = elementKind == .header
         let supplementaryModel = isHeader ? sectionModel.headerViewModel : sectionModel.footerViewModel
         if let height = supplementaryModel?.height {
@@ -197,13 +197,13 @@ extension CollectionViewDriver: UICollectionViewDataSource {
 
     /// :nodoc:
     public func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        guard let sectionModel = self.collectionViewModel?[section] else { return 0 }
+        guard let sectionModel = self.collectionViewModel?[ifExists: section] else { return 0 }
         return sectionModel.cellViewModels.count
     }
 
     /// :nodoc:
     public func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        guard let collectionViewModel = self.collectionViewModel, let cellViewModel = collectionViewModel[indexPath] else {
+        guard let collectionViewModel = self.collectionViewModel, let cellViewModel = collectionViewModel[ifExists: indexPath] else {
             fatalError("Collection View Model has an invalid configuration: \(String(describing: self.collectionViewModel))")
         }
         return collectionView.configuredCell(for: cellViewModel, at: indexPath)
@@ -216,7 +216,7 @@ extension CollectionViewDriver: UICollectionViewDataSource {
         let view: UICollectionReusableView
 
         if let elementKind = elementKind,
-            let sectionModel = self.collectionViewModel?[section],
+            let sectionModel = self.collectionViewModel?[ifExists: section],
             let viewModel = elementKind == .header ? sectionModel.headerViewModel : sectionModel.footerViewModel,
             let identifier = viewModel.viewInfo?.registrationInfo.reuseIdentifier {
             view = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: identifier, for: indexPath)
@@ -236,17 +236,17 @@ extension CollectionViewDriver: UICollectionViewDelegate {
         if self._shouldDeselectUponSelection {
             collectionView.deselectItem(at: indexPath, animated: true)
         }
-        self.collectionViewModel?[indexPath]?.didSelect?()
+        self.collectionViewModel?[ifExists: indexPath]?.didSelect?()
     }
 
     /// :nodoc:
     public func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {
-        self.collectionViewModel?[indexPath]?.didDeselect?()
+        self.collectionViewModel?[ifExists: indexPath]?.didDeselect?()
     }
 
     /// :nodoc:
     public func collectionView(_ collectionView: UICollectionView, shouldHighlightItemAt indexPath: IndexPath) -> Bool {
-        return self.collectionViewModel?[indexPath]?.shouldHighlight ?? true
+        return self.collectionViewModel?[ifExists: indexPath]?.shouldHighlight ?? true
     }
 }
 

--- a/Sources/CollectionViewModel.swift
+++ b/Sources/CollectionViewModel.swift
@@ -97,7 +97,7 @@ public struct CollectionViewModel {
     /// Returns the section model at the specified index or `nil` if no such section exists.
     ///
     /// - Parameter section: the index for the section that is being retrieved
-    public subscript(section: Int) -> CollectionSectionViewModel? {
+    public subscript(ifExists section: Int) -> CollectionSectionViewModel? {
         guard self.sectionModels.count > section else { return nil }
         return sectionModels[section]
     }
@@ -105,8 +105,8 @@ public struct CollectionViewModel {
     /// Returns the cell view model at the specified index path or `nil` if no such cell exists.
     ///
     /// - Parameter indexPath: the index path for the cell that is being retrieved
-    public subscript(indexPath: IndexPath) -> CollectionCellViewModel? {
-        guard let section = self[indexPath.section], section.cellViewModels.count > indexPath.item else { return nil }
+    public subscript(ifExists indexPath: IndexPath) -> CollectionCellViewModel? {
+        guard let section = self[ifExists: indexPath.section], section.cellViewModels.count > indexPath.item else { return nil }
         return section.cellViewModels[indexPath.item]
     }
 

--- a/Sources/TableViewDriver.swift
+++ b/Sources/TableViewDriver.swift
@@ -111,7 +111,7 @@ open class TableViewDriver: NSObject {
 
         // Collect the index paths and views models to reload
         let indexPathsAndViewModelsToReload = visibleIndexPaths.compactMap { indexPath in
-            return self.tableViewModel?[indexPath].map { (indexPath, $0) }
+            return self.tableViewModel?[ifExists: indexPath].map { (indexPath, $0) }
         }
 
         if !indexPathsAndViewModelsToReload.isEmpty {
@@ -137,7 +137,7 @@ open class TableViewDriver: NSObject {
 
         let visibleSections = Set<Int>(visibleIndexPaths.map { $0.section })
         for section in visibleSections {
-            guard let sectionModel = self.tableViewModel?[section] else { continue }
+            guard let sectionModel = self.tableViewModel?[ifExists: section] else { continue }
 
             if let headerView = self.tableView.headerView(forSection: section),
                 let headerViewModel = sectionModel.headerViewModel {
@@ -211,7 +211,7 @@ open class TableViewDriver: NSObject {
     }
 
     private func _tableView(_ tableView: UITableView, viewForSection section: Int, viewKind: SupplementaryViewKind) -> UIView? {
-        guard let sectionModel = self.tableViewModel?[section],
+        guard let sectionModel = self.tableViewModel?[ifExists: section],
             let viewModel = viewKind == .header ? sectionModel.headerViewModel : sectionModel.footerViewModel,
             let identifier = viewModel.viewInfo?.registrationInfo.reuseIdentifier,
             let view = tableView.dequeueReusableHeaderFooterView(withIdentifier: identifier) else {
@@ -227,7 +227,7 @@ extension TableViewDriver: UITableViewDataSource {
 
     /// :nodoc:
     public func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        guard let tableViewModel = self.tableViewModel, let cellViewModel = tableViewModel[indexPath] else {
+        guard let tableViewModel = self.tableViewModel, let cellViewModel = tableViewModel[ifExists: indexPath] else {
             fatalError("Table View Model has an invalid configuration: \(String(describing: self.tableViewModel))")
         }
         return tableView.configuredCell(for: cellViewModel, at: indexPath)
@@ -240,25 +240,25 @@ extension TableViewDriver: UITableViewDataSource {
 
     /// :nodoc:
     public func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        guard let sectionModel = self.tableViewModel?[section] else { return 0 }
+        guard let sectionModel = self.tableViewModel?[ifExists: section] else { return 0 }
         return sectionModel.cellViewModels.count
     }
 
     /// :nodoc:
     public func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
-        guard let header = self.tableViewModel?[section]?.headerViewModel, header.viewInfo == nil else { return nil }
+        guard let header = self.tableViewModel?[ifExists: section]?.headerViewModel, header.viewInfo == nil else { return nil }
         return header.title
     }
 
     /// :nodoc:
     public func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
-        guard let footer = self.tableViewModel?[section]?.footerViewModel, footer.viewInfo == nil else { return nil }
+        guard let footer = self.tableViewModel?[ifExists: section]?.footerViewModel, footer.viewInfo == nil else { return nil }
         return footer.title
     }
 
     /// :nodoc:
     public func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCellEditingStyle, forRowAt indexPath: IndexPath) {
-        self.tableViewModel?[indexPath]?.commitEditingStyle?(editingStyle)
+        self.tableViewModel?[ifExists: indexPath]?.commitEditingStyle?(editingStyle)
     }
 
     /// :nodoc:
@@ -271,7 +271,7 @@ extension TableViewDriver: UITableViewDelegate {
 
     /// :nodoc:
     public func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        return self.tableViewModel?[indexPath]?.rowHeight ?? 44
+        return self.tableViewModel?[ifExists: indexPath]?.rowHeight ?? 44
     }
 
     /// :nodoc:
@@ -286,17 +286,17 @@ extension TableViewDriver: UITableViewDelegate {
 
     /// :nodoc:
     public func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        return self.tableViewModel?[section]?.headerViewModel?.height ?? CGFloat.leastNormalMagnitude
+        return self.tableViewModel?[ifExists: section]?.headerViewModel?.height ?? CGFloat.leastNormalMagnitude
     }
 
     /// :nodoc:
     public func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
-        return self.tableViewModel?[section]?.footerViewModel?.height ?? CGFloat.leastNormalMagnitude
+        return self.tableViewModel?[ifExists: section]?.footerViewModel?.height ?? CGFloat.leastNormalMagnitude
     }
 
     /// :nodoc:
     public func tableView(_ tableView: UITableView, editActionsForRowAt indexPath: IndexPath) -> [UITableViewRowAction]? {
-        if let cellViewModel = self.tableViewModel?[indexPath] as? TableViewCellModelEditActions {
+        if let cellViewModel = self.tableViewModel?[ifExists: indexPath] as? TableViewCellModelEditActions {
             return cellViewModel.editActions
         }
         return nil
@@ -304,7 +304,7 @@ extension TableViewDriver: UITableViewDelegate {
 
     /// :nodoc:
     public func tableView(_ tableView: UITableView, accessoryButtonTappedForRowWith indexPath: IndexPath) {
-        self.tableViewModel?[indexPath]?.accessoryButtonTapped?()
+        self.tableViewModel?[ifExists: indexPath]?.accessoryButtonTapped?()
     }
 
     /// :nodoc:
@@ -312,33 +312,33 @@ extension TableViewDriver: UITableViewDelegate {
         if self._shouldDeselectUponSelection {
             tableView.deselectRow(at: indexPath, animated: true)
         }
-        self.tableViewModel?[indexPath]?.didSelect?()
+        self.tableViewModel?[ifExists: indexPath]?.didSelect?()
     }
 
     /// :nodoc:
     public func tableView(_ tableView: UITableView, willBeginEditingRowAt indexPath: IndexPath) {
-        self.tableViewModel?[indexPath]?.willBeginEditing?()
+        self.tableViewModel?[ifExists: indexPath]?.willBeginEditing?()
     }
 
     /// :nodoc:
     public func tableView(_ tableView: UITableView, didEndEditingRowAt indexPath: IndexPath?) {
         if let indexPath = indexPath {
-            self.tableViewModel?[indexPath]?.didEndEditing?()
+            self.tableViewModel?[ifExists: indexPath]?.didEndEditing?()
         }
     }
 
     /// :nodoc:
     public func tableView(_ tableView: UITableView, editingStyleForRowAt indexPath: IndexPath) -> UITableViewCellEditingStyle {
-        return self.tableViewModel?[indexPath]?.editingStyle ?? .none
+        return self.tableViewModel?[ifExists: indexPath]?.editingStyle ?? .none
     }
 
     /// :nodoc:
     public func tableView(_ tableView: UITableView, shouldIndentWhileEditingRowAt indexPath: IndexPath) -> Bool {
-        return self.tableViewModel?[indexPath]?.shouldIndentWhileEditing ?? true
+        return self.tableViewModel?[ifExists: indexPath]?.shouldIndentWhileEditing ?? true
     }
 
     /// :nodoc:
     public func tableView(_ tableView: UITableView, shouldHighlightRowAt indexPath: IndexPath) -> Bool {
-        return self.tableViewModel?[indexPath]?.shouldHighlight ?? true
+        return self.tableViewModel?[ifExists: indexPath]?.shouldHighlight ?? true
     }
 }

--- a/Sources/TableViewModel.swift
+++ b/Sources/TableViewModel.swift
@@ -218,7 +218,7 @@ public struct TableViewModel {
     /// Returns the section model at the specified index or `nil` if no such section exists.
     ///
     /// - Parameter section: the index for the section that is being retrieved
-    public subscript(section: Int) -> TableSectionViewModel? {
+    public subscript(ifExists section: Int) -> TableSectionViewModel? {
         guard sectionModels.count > section else { return nil }
         return sectionModels[section]
     }
@@ -226,9 +226,9 @@ public struct TableViewModel {
     /// Returns the cell view model at the specified index path or `nil` if no such cell exists.
     ///
     /// - Parameter indexPath: the index path for the cell that is being retrieved
-    public subscript(indexPath: IndexPath) -> TableCellViewModel? {
+    public subscript(ifExists indexPath: IndexPath) -> TableCellViewModel? {
         guard indexPath.count >= 2, // In rare cases, we've seen UIKit give us a bad IndexPath
-            let section = self[indexPath.section],
+            let section = self[ifExists: indexPath.section],
             section.cellViewModels.count > indexPath.row else { return nil }
         return section.cellViewModels[indexPath.row]
     }

--- a/Tests/CollectionView/CollectionViewModelTests.swift
+++ b/Tests/CollectionView/CollectionViewModelTests.swift
@@ -66,13 +66,13 @@ final class CollectionViewModelTests: XCTestCase {
         ])
 
         // Returns `nil` when there's no cell/section at the provided path.
-        XCTAssertNil(collectionViewModel[9]?.headerViewModel?.height)
-        XCTAssertNil(collectionViewModel[IndexPath(row: 0, section: 0)])
-        XCTAssertNil(collectionViewModel[IndexPath(row: 0, section: 9)])
-        XCTAssertNil(collectionViewModel[IndexPath(row: 9, section: 1)])
+        XCTAssertNil(collectionViewModel[ifExists: 9]?.headerViewModel?.height)
+        XCTAssertNil(collectionViewModel[ifExists: IndexPath(row: 0, section: 0)])
+        XCTAssertNil(collectionViewModel[ifExists: IndexPath(row: 0, section: 9)])
+        XCTAssertNil(collectionViewModel[ifExists: IndexPath(row: 9, section: 1)])
 
         // Returns the section/cell model, if the index path exists within the table view model.
-        let cell_row_0_section_1 = collectionViewModel[IndexPath(row: 0, section: 1)]
+        let cell_row_0_section_1 = collectionViewModel[ifExists: IndexPath(row: 0, section: 1)]
             as? TestCollectionCellViewModel
         XCTAssertEqual(cell_row_0_section_1?.label, "A")
     }

--- a/Tests/TableView/TableViewModelTests.swift
+++ b/Tests/TableView/TableViewModelTests.swift
@@ -39,15 +39,15 @@ final class TableViewModelTests: XCTestCase {
         ])
 
         // Returns `nil` when there's no cell/section at the provided path.
-        XCTAssertNil(tableViewModel[9]?.headerViewModel?.title)
-        XCTAssertNil(tableViewModel[IndexPath(row: 0, section: 0)])
-        XCTAssertNil(tableViewModel[IndexPath(row: 0, section: 9)])
-        XCTAssertNil(tableViewModel[IndexPath(row: 9, section: 1)])
+        XCTAssertNil(tableViewModel[ifExists: 9]?.headerViewModel?.title)
+        XCTAssertNil(tableViewModel[ifExists: IndexPath(row: 0, section: 0)])
+        XCTAssertNil(tableViewModel[ifExists: IndexPath(row: 0, section: 9)])
+        XCTAssertNil(tableViewModel[ifExists: IndexPath(row: 9, section: 1)])
 
         // Returns the section/cell model, if the index path exists within the table view model.
-        XCTAssertEqual(tableViewModel[0]?.headerViewModel?.title, "section_1")
-        XCTAssertEqual((tableViewModel[IndexPath(row: 0, section: 1)] as? TestCellViewModel)?.label, "A")
-        XCTAssertNil(tableViewModel[[] as IndexPath])
+        XCTAssertEqual(tableViewModel[ifExists: 0]?.headerViewModel?.title, "section_1")
+        XCTAssertEqual((tableViewModel[ifExists: IndexPath(row: 0, section: 1)] as? TestCellViewModel)?.label, "A")
+        XCTAssertNil(tableViewModel[ifExists: [] as IndexPath])
     }
 
     /// The `.isEmpty` property of the table view.


### PR DESCRIPTION
## Changes in this pull request

This adds `ifExists:` to the subscript methods that return an `Optional`. This will help, if/when we move forward with `Collection` conformance for `TableViewModel` and `CollectionViewModel` because `Collection` subscript methods have a non-`Optional` return type.

### Checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have reviewed the [contributing guide](https://github.com/plangrid/ReactiveLists/blob/master/.github/CONTRIBUTING.md)