### PR TITLE
Add Collection conformance for *SectionModel types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ The changelog for `ReactiveLists`. Also see the [releases](https://github.com/pl
 
 This release closes the [0.2.0 milestone](https://github.com/plangrid/ReactiveLists/milestone/2).
 
+### New
+
+- `TableSectionViewModel` and `CollectionSectionViewModel` now implement `Collection` ([#135](https://github.com/plangrid/ReactiveLists/pull/135), [@benasher44](https://github.com/benasher44))
+
 0.1.4
 -----
 

--- a/Sources/CollectionViewModel.swift
+++ b/Sources/CollectionViewModel.swift
@@ -167,3 +167,22 @@ public struct CollectionSectionViewModel: DiffableViewModel {
         self.diffingKey = diffingKey
     }
 }
+
+/// Collection support for diffing
+extension CollectionSectionViewModel: Collection {
+    public subscript(position: Int) -> CollectionCellViewModel {
+        return self.cellViewModels[position]
+    }
+
+    public func index(after i: Int) -> Int {
+        return self.cellViewModels.index(after: i)
+    }
+
+    public var startIndex: Int {
+        return self.cellViewModels.startIndex
+    }
+
+    public var endIndex: Int {
+        return self.cellViewModels.endIndex
+    }
+}

--- a/Sources/CollectionViewModel.swift
+++ b/Sources/CollectionViewModel.swift
@@ -168,20 +168,24 @@ public struct CollectionSectionViewModel: DiffableViewModel {
     }
 }
 
-/// Collection support for diffing
+/// `Collection` support for diffing
 extension CollectionSectionViewModel: Collection {
+    /// :nodoc:
     public subscript(position: Int) -> CollectionCellViewModel {
         return self.cellViewModels[position]
     }
 
+    /// :nodoc:
     public func index(after i: Int) -> Int {
         return self.cellViewModels.index(after: i)
     }
 
+    /// :nodoc:
     public var startIndex: Int {
         return self.cellViewModels.startIndex
     }
 
+    /// :nodoc:
     public var endIndex: Int {
         return self.cellViewModels.endIndex
     }

--- a/Sources/TableViewModel.swift
+++ b/Sources/TableViewModel.swift
@@ -181,6 +181,25 @@ public struct TableSectionViewModel: DiffableViewModel {
     }
 }
 
+/// Collection support for diffing
+extension TableSectionViewModel: Collection {
+    public subscript(position: Int) -> TableCellViewModel {
+        return self.cellViewModels[position]
+    }
+
+    public func index(after i: Int) -> Int {
+        return self.cellViewModels.index(after: i)
+    }
+
+    public var startIndex: Int {
+        return self.cellViewModels.startIndex
+    }
+
+    public var endIndex: Int {
+        return self.cellViewModels.endIndex
+    }
+}
+
 /// The view model that describes a `UITableView`.
 public struct TableViewModel {
 

--- a/Sources/TableViewModel.swift
+++ b/Sources/TableViewModel.swift
@@ -181,20 +181,25 @@ public struct TableSectionViewModel: DiffableViewModel {
     }
 }
 
-/// Collection support for diffing
+/// `Collection` support for diffing
 extension TableSectionViewModel: Collection {
+
+    /// :nodoc:
     public subscript(position: Int) -> TableCellViewModel {
         return self.cellViewModels[position]
     }
 
+    /// :nodoc:
     public func index(after i: Int) -> Int {
         return self.cellViewModels.index(after: i)
     }
 
+    /// :nodoc:
     public var startIndex: Int {
         return self.cellViewModels.startIndex
     }
 
+    /// :nodoc:
     public var endIndex: Int {
         return self.cellViewModels.endIndex
     }

--- a/Tests/CollectionView/CollectionViewModelTests.swift
+++ b/Tests/CollectionView/CollectionViewModelTests.swift
@@ -98,4 +98,17 @@ final class CollectionViewModelTests: XCTestCase {
         let viewModel5 = CollectionViewModel(sectionModels: [section0, sectionEmpty, section2])
         XCTAssertFalse(viewModel5.isEmpty)
     }
+
+    /// Verify Collection conformace
+    func testSectionCollection() {
+        let section = CollectionSectionViewModel(
+            cellViewModels: generateCollectionCellViewModels()
+        )
+        let sectionLabels = section.cellViewModels.compactMap {
+            ($0 as? TestCollectionCellViewModel)?.label
+        }
+        let sectionLabelsViaCollection = section.compactMap { ($0 as? TestCollectionCellViewModel)?.label }
+        XCTAssertFalse(sectionLabels.isEmpty)
+        XCTAssertEqual(sectionLabels, sectionLabelsViaCollection)
+    }
 }

--- a/Tests/TableView/TableViewModelTests.swift
+++ b/Tests/TableView/TableViewModelTests.swift
@@ -125,4 +125,17 @@ final class TableViewModelTests: XCTestCase {
             "access_footer+44"
         )
     }
+
+    /// Verify Collection conformace
+    func testSectionCollection() {
+        let section = TableSectionViewModel(
+            cellViewModels: generateTableCellViewModels()
+        )
+        let sectionLabels = section.cellViewModels.compactMap {
+            ($0 as? TestCellViewModel)?.label
+        }
+        let sectionLabelsViaCollection = section.compactMap { ($0 as? TestCellViewModel)?.label }
+        XCTAssertFalse(sectionLabels.isEmpty)
+        XCTAssertEqual(sectionLabels, sectionLabelsViaCollection)
+    }
 }


### PR DESCRIPTION
## Changes in this pull request

This adds `Collection` conformance to *`SectionModel` types, which eases upgrading to Swift-based, non-Dwifft diffing (most diff `Collection`s).

### Checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have reviewed the [contributing guide](https://github.com/plangrid/ReactiveLists/blob/master/.github/CONTRIBUTING.md)