### PR TITLE
Don't store an empty model for the first non-nil differ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,19 @@ The changelog for `ReactiveLists`. Also see the [releases](https://github.com/pl
 
 ------
 
-0.2.0 (NEXT)
-------------
+0.2.0
+-----
 
 This release closes the [0.2.0 milestone](https://github.com/plangrid/ReactiveLists/milestone/2).
+
+0.1.4 (NEXT)
+------------
+
+This release closes the [0.1.4 milestone](https://github.com/plangrid/ReactiveLists/milestone/7).
+
+### Fixed
+
+Don't store an empty model for the first non-nil differ. ([#137](https://github.com/plangrid/ReactiveLists/pull/137), [@benasher44](https://github.com/benasher44))
 
 0.1.3
 -----

--- a/Sources/CollectionViewDriver.swift
+++ b/Sources/CollectionViewDriver.swift
@@ -51,7 +51,8 @@ public class CollectionViewDriver: NSObject {
 
     private var _shouldDeselectUponSelection: Bool
 
-    private var _differ: CollectionViewDiffCalculator<DiffingKey, DiffingKey>?
+    // internal for testing
+    var _differ: CollectionViewDiffCalculator<DiffingKey, DiffingKey>?
     private let _automaticDiffingEnabled: Bool
     private var _didReceiveFirstNonNilNonEmptyValue = false
 
@@ -144,7 +145,7 @@ public class CollectionViewDriver: NSObject {
             self.collectionView.reloadData()
 
             if self._automaticDiffingEnabled
-                && self.collectionViewModel != nil
+                && !nextStateNilOrEmpty
                 && !self._didReceiveFirstNonNilNonEmptyValue {
                 // Special case for the first non-nil value
                 // Now that we have this initial state, setup the differ with that initial state,

--- a/Sources/TableViewDriver.swift
+++ b/Sources/TableViewDriver.swift
@@ -67,7 +67,8 @@ open class TableViewDriver: NSObject {
 
     private let _shouldDeselectUponSelection: Bool
 
-    private var _differ: TableViewDiffCalculator<DiffingKey, DiffingKey>?
+    // internal for testing
+    var _differ: TableViewDiffCalculator<DiffingKey, DiffingKey>?
     private let _automaticDiffingEnabled: Bool
     private var _didReceiveFirstNonNilNonEmptyValue = false
 
@@ -171,7 +172,7 @@ open class TableViewDriver: NSObject {
             self.tableView.reloadData()
 
             if self._automaticDiffingEnabled
-                && self.tableViewModel != nil
+                && !nextStateNilOrEmpty
                 && !self._didReceiveFirstNonNilNonEmptyValue {
                 // Special case for the first non-nil value
                 // Now that we have this initial state, setup the differ with that initial state,

--- a/Tests/CollectionView/CollectionViewDriverTests.swift
+++ b/Tests/CollectionView/CollectionViewDriverTests.swift
@@ -231,6 +231,15 @@ final class CollectionViewDriverTests: XCTestCase {
         XCTAssertEqual(footer?.accessibilityIdentifier, "access_footer+0")
     }
 
+    /// The setting an empty model shouldn't trigger diffing setup
+    func testDifferNotSetForEmptyModel() {
+        let collectionView = TestCollectionView(frame: .zero, collectionViewLayout: UICollectionViewLayout())
+        let dataSource = CollectionViewDriver(collectionView: collectionView)
+        XCTAssertNil(dataSource._differ)
+        dataSource.collectionViewModel = CollectionViewModel(sectionModels: [])
+        XCTAssertNil(dataSource._differ)
+    }
+
     private func _getItem(_ path: IndexPath) -> TestCollectionViewCell? {
         guard let cell = self._collectionViewDataSource.collectionView(self._collectionView,
                                                                            cellForItemAt: path) as? TestCollectionViewCell else { return nil }

--- a/Tests/TableView/TableViewDriverTests.swift
+++ b/Tests/TableView/TableViewDriverTests.swift
@@ -272,6 +272,15 @@ final class TableViewDriverTests: XCTestCase {
         XCTAssertNil(defaultCellViewModel.accessoryButtonTapped)
         XCTAssertFalse(defaultCellViewModel.shouldIndentWhileEditing)
     }
+
+    /// The setting an empty model shouldn't trigger diffing setup
+    func testDifferNotSetForEmptyModel() {
+        let tableView = TestTableView()
+        let dataSource = TableViewDriver(tableView: tableView)
+        XCTAssertNil(dataSource._differ)
+        dataSource.tableViewModel = TableViewModel(sectionModels: [])
+        XCTAssertNil(dataSource._differ)
+    }
 }
 
 // MARK: Test data generation


### PR DESCRIPTION
## Changes in this pull request

This fixes a regression where we started storing empty values for the first non-nil value (i.e. the first value to start diffing from). This caused crashes in some scenarios.

### Checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have reviewed the [contributing guide](https://github.com/plangrid/ReactiveLists/blob/master/.github/CONTRIBUTING.md)
