### PR TITLE
Make section `diffingKey` parameter required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ The changelog for `ReactiveLists`. Also see the [releases](https://github.com/pl
 
 This release closes the [0.4.0 milestone](https://github.com/plangrid/ReactiveLists/milestone/10).
 
+### Breaking
+
+- Updates the initializers for `TableSectionViewModel` and `CollectionSectionViewModel` so that the `diffingKey` argument is _required_. This prevents accidental misuse of the automatic diffing API, which was possible if you relied on the previous default parameter value. (#147, @ronaldsmartin)
+
 0.3.0
 -----
 

--- a/Example/CollectionViewController.swift
+++ b/Example/CollectionViewController.swift
@@ -79,7 +79,11 @@ extension CollectionViewController {
                     accessibilityFormat: "CollectionViewHeaderView"
                 )
             )
-            return CollectionSectionViewModel(cellViewModels: cellViewModels, headerViewModel: headerViewModel, diffingKey: group.name)
+            return CollectionSectionViewModel(
+                diffingKey: group.name,
+                cellViewModels: cellViewModels,
+                headerViewModel: headerViewModel
+            )
         }
         return CollectionViewModel(sectionModels: sections)
     }

--- a/Example/TableViewController.swift
+++ b/Example/TableViewController.swift
@@ -71,10 +71,10 @@ extension TableViewController {
         let sections: [TableSectionViewModel] = groups.map { group in
             let cellViewModels = group.tools.map { ToolTableCellModel(tool: $0, onDeleteClosure: onDeleteClosure) }
             return TableSectionViewModel(
+                diffingKey: group.name,
                 headerTitle: group.name,
                 headerHeight: 44,
-                cellViewModels: cellViewModels,
-                diffingKey: group.name
+                cellViewModels: cellViewModels
             )
         }
         return TableViewModel(sectionModels: sections)

--- a/Sources/CollectionViewModel.swift
+++ b/Sources/CollectionViewModel.swift
@@ -140,19 +140,21 @@ public struct CollectionSectionViewModel: DiffableViewModel {
     /// Initializes a collection view section view model.
     ///
     /// - Parameters:
+    ///   - diffingKey: a `String` key unique to this section that is used to diff sections
+    ///     automatically. Pass in `nil` if you are not using automatic diffing on this collection.
     ///   - cellViewModels: the cells in this section.
     ///   - headerViewModel: the header view model (defaults to `nil`).
     ///   - footerViewModel: the footer view model (defaults to `nil`).
-    ///   - diffingKey: the diffing key, required for automated diffing.
     public init(
+        diffingKey: String?,
         cellViewModels: [CollectionCellViewModel],
         headerViewModel: CollectionSupplementaryViewModel? = nil,
-        footerViewModel: CollectionSupplementaryViewModel? = nil,
-        diffingKey: String = UUID().uuidString) {
+        footerViewModel: CollectionSupplementaryViewModel? = nil
+    ) {
         self.cellViewModels = cellViewModels
         self.headerViewModel = headerViewModel
         self.footerViewModel = footerViewModel
-        self.diffingKey = diffingKey
+        self.diffingKey = diffingKey ?? UUID().uuidString
     }
 }
 

--- a/Sources/Diffing.swift
+++ b/Sources/Diffing.swift
@@ -117,11 +117,11 @@ extension TableSectionViewModel: DifferentiableSection {
     /// :nodoc:
     public init<C: Collection>(source: TableSectionViewModel, elements: C) where C.Element == AnyDiffableViewModel {
         self.init(
+            diffingKey: source.diffingKey,
             //swiftlint:disable:next force_cast
             cellViewModels: elements.map { $0.model as! TableCellViewModel },
             headerViewModel: source.headerViewModel,
-            footerViewModel: source.footerViewModel,
-            diffingKey: source.diffingKey
+            footerViewModel: source.footerViewModel
         )
     }
 }

--- a/Sources/Diffing.swift
+++ b/Sources/Diffing.swift
@@ -150,11 +150,11 @@ extension CollectionSectionViewModel: DifferentiableSection {
     /// :nodoc:
     public init<C: Collection>(source: CollectionSectionViewModel, elements: C) where C.Element == AnyDiffableViewModel {
         self.init(
+            diffingKey: source.diffingKey,
             //swiftlint:disable:next force_cast
             cellViewModels: elements.map { $0.model as! CollectionCellViewModel },
             headerViewModel: source.headerViewModel,
-            footerViewModel: source.footerViewModel,
-            diffingKey: source.diffingKey
+            footerViewModel: source.footerViewModel
         )
     }
 }

--- a/Sources/TableViewModel.swift
+++ b/Sources/TableViewModel.swift
@@ -142,19 +142,21 @@ public struct TableSectionViewModel: DiffableViewModel {
     /// Initializes a `TableSectionViewModel`.
     ///
     /// - Parameters:
+    ///   - diffingKey: a `String` key unique to this section that is used to diff sections
+    ///     automatically. Pass in `nil` if you are not using automatic diffing on this collection.
     ///   - cellViewModels: The cell view models contained in this section.
     ///   - headerViewModel: A header view model for this section (defaults to `nil`).
     ///   - footerViewModel: A footer view model for this section (defaults to `nil`).
-    ///   - diffingKey: A diffing key.
     public init(
+        diffingKey: String?,
         cellViewModels: [TableCellViewModel],
         headerViewModel: TableSectionHeaderFooterViewModel? = nil,
-        footerViewModel: TableSectionHeaderFooterViewModel? = nil,
-        diffingKey: String = UUID().uuidString) {
+        footerViewModel: TableSectionHeaderFooterViewModel? = nil
+    ) {
         self.cellViewModels = cellViewModels
         self.headerViewModel = headerViewModel
         self.footerViewModel = footerViewModel
-        self.diffingKey = diffingKey
+        self.diffingKey = diffingKey ?? UUID().uuidString
     }
 
     /// Initializes a `TableSectionViewModel`.
@@ -167,16 +169,17 @@ public struct TableSectionViewModel: DiffableViewModel {
     ///   - footerHeight: The height of the default footer, if one exists.
     ///   - diffingKey: A diffing key.
     public init(
+        diffingKey: String?,
         headerTitle: String?,
         headerHeight: CGFloat?,
         cellViewModels: [TableCellViewModel],
         footerTitle: String? = nil,
-        footerHeight: CGFloat? = 0,
-        diffingKey: String = UUID().uuidString) {
+        footerHeight: CGFloat? = 0
+    ) {
         self.cellViewModels = cellViewModels
         self.headerViewModel = PlainHeaderFooterViewModel(title: headerTitle, height: headerHeight)
         self.footerViewModel = PlainHeaderFooterViewModel(title: footerTitle, height: footerHeight)
-        self.diffingKey = diffingKey
+        self.diffingKey = diffingKey ?? UUID().uuidString
     }
 }
 
@@ -223,7 +226,10 @@ public struct TableViewModel {
     ///
     /// - Parameter cellViewModels: the cell models for the only section in this table.
     public init(cellViewModels: [TableCellViewModel]) {
-        let section = TableSectionViewModel(cellViewModels: cellViewModels, diffingKey: "default_section")
+        let section = TableSectionViewModel(
+            diffingKey: "default_section",
+            cellViewModels: cellViewModels
+        )
         self.init(sectionModels: [section])
     }
 

--- a/Tests/CollectionView/CollectionViewDriverDiffingTests.swift
+++ b/Tests/CollectionView/CollectionViewDriverDiffingTests.swift
@@ -44,8 +44,8 @@ final class CollectionViewDriverDiffingTests: XCTestCase {
         let initialModel = CollectionViewModel(
             sectionModels: [
                 CollectionSectionViewModel(
-                    cellViewModels: [],
-                    diffingKey: "1"
+                    diffingKey: "1",
+                    cellViewModels: []
                 )
             ]
         )
@@ -55,8 +55,8 @@ final class CollectionViewDriverDiffingTests: XCTestCase {
         let updatedModel = CollectionViewModel(
             sectionModels: [
                 CollectionSectionViewModel(
-                    cellViewModels: [CollectionUserCellModel(user: User(name: "Mona"))],
-                    diffingKey: "1"
+                    diffingKey: "1",
+                    cellViewModels: [CollectionUserCellModel(user: User(name: "Mona"))]
                 )
             ]
         )
@@ -74,11 +74,17 @@ final class CollectionViewDriverDiffingTests: XCTestCase {
     ///   communication between the diffing lib and the collection view. The diffing lib itself has
     ///   extensive tests for the various diffing scenarios.
     func testChangingSections() {
-        let section = CollectionSectionViewModel(cellViewModels: generateCollectionCellViewModels(), diffingKey: "2")
+        let section = CollectionSectionViewModel(
+            diffingKey: "2",
+            cellViewModels: generateCollectionCellViewModels()
+        )
 
         let initialModel = CollectionViewModel(
             sectionModels: [
-                CollectionSectionViewModel( cellViewModels: generateCollectionCellViewModels(), diffingKey: "1"),
+                CollectionSectionViewModel(
+                    diffingKey: "1",
+                    cellViewModels: generateCollectionCellViewModels()
+                ),
                 section,
             ]
         )

--- a/Tests/CollectionView/CollectionViewDriverTests.swift
+++ b/Tests/CollectionView/CollectionViewDriverTests.swift
@@ -32,21 +32,43 @@ final class CollectionViewDriverTests: XCTestCase {
         self._collectionView = TestCollectionView(frame: CGRect.zero, collectionViewLayout: UICollectionViewLayout())
         self._collectionViewModel = CollectionViewModel(sectionModels: [
             CollectionSectionViewModel(
+                diffingKey: nil,
                 cellViewModels: [],
-                headerViewModel: TestCollectionViewSupplementaryViewModel(height: 10, viewKind: .header, sectionLabel: "A"),
-                footerViewModel: TestCollectionViewSupplementaryViewModel(height: 11, viewKind: .footer, sectionLabel: "A")),
+                headerViewModel: TestCollectionViewSupplementaryViewModel(
+                    height: 10,
+                    viewKind: .header,
+                    sectionLabel: "A"
+                ),
+                footerViewModel: TestCollectionViewSupplementaryViewModel(
+                    height: 11,
+                    viewKind: .footer,
+                    sectionLabel: "A"
+                )
+            ),
             CollectionSectionViewModel(
+                diffingKey: nil,
                 cellViewModels: ["A", "B", "C"].map { self._generateTestCollectionCellViewModel($0) },
                 headerViewModel: nil,
                 footerViewModel: TestCollectionViewSupplementaryViewModel(label: "footer_B", height: 21)),
             CollectionSectionViewModel(
+                diffingKey: nil,
                 cellViewModels: ["D", "E", "F"].map { self._generateTestCollectionCellViewModel($0) },
                 headerViewModel: TestCollectionViewSupplementaryViewModel(label: "header_C", height: 30),
                 footerViewModel: nil),
             CollectionSectionViewModel(
+                diffingKey: nil,
                 cellViewModels: [],
-                headerViewModel: TestCollectionViewSupplementaryViewModel(height: nil, viewKind: .header, sectionLabel: "D"),
-                footerViewModel: TestCollectionViewSupplementaryViewModel(height: nil, viewKind: .footer, sectionLabel: "D")),
+                headerViewModel: TestCollectionViewSupplementaryViewModel(
+                    height: nil,
+                    viewKind: .header,
+                    sectionLabel: "D"
+                ),
+                footerViewModel: TestCollectionViewSupplementaryViewModel(
+                    height: nil,
+                    viewKind: .footer,
+                    sectionLabel: "D"
+                )
+            ),
         ])
         self._collectionViewDataSource = CollectionViewDriver(
             collectionView: self._collectionView,
@@ -209,10 +231,12 @@ final class CollectionViewDriverTests: XCTestCase {
 
         self._collectionViewDataSource.collectionViewModel = CollectionViewModel(sectionModels: [
             CollectionSectionViewModel(
+                diffingKey: nil,
                 cellViewModels: [],
                 headerViewModel: TestCollectionViewSupplementaryViewModel(height: 10, viewKind: .header, sectionLabel: "X"),
                 footerViewModel: TestCollectionViewSupplementaryViewModel(height: 11, viewKind: .footer, sectionLabel: "X")),
             CollectionSectionViewModel(
+                diffingKey: nil,
                 cellViewModels: [self._generateTestCollectionCellViewModel("X")],
                 headerViewModel: nil,
                 footerViewModel: nil),

--- a/Tests/CollectionView/CollectionViewModelTests.swift
+++ b/Tests/CollectionView/CollectionViewModelTests.swift
@@ -22,6 +22,7 @@ final class CollectionViewModelTests: XCTestCase {
     /// Can be initialized with a custom header and footer view.
     func testViewModelInitializerWithCustomHeaderAndFooter() {
         let sectionModel = CollectionSectionViewModel(
+            diffingKey: nil,
             cellViewModels: [generateTestCollectionCellViewModel()],
             headerViewModel: TestCollectionViewSupplementaryViewModel(
                 height: 40,
@@ -56,8 +57,9 @@ final class CollectionViewModelTests: XCTestCase {
     /// model returns `nil`.
     func testSubscripts() {
         let collectionViewModel = CollectionViewModel(sectionModels: [
-            CollectionSectionViewModel(cellViewModels: []),
+            CollectionSectionViewModel(diffingKey: nil, cellViewModels: []),
             CollectionSectionViewModel(
+                diffingKey: nil,
                 cellViewModels: [
                     generateTestCollectionCellViewModel("A"),
                     generateTestCollectionCellViewModel("B"),
@@ -79,9 +81,15 @@ final class CollectionViewModelTests: XCTestCase {
 
     /// The `.isEmpty` property of the collection view.
     func testIsEmpty() {
-        let section0 = CollectionSectionViewModel(cellViewModels: generateCollectionCellViewModels())
-        let sectionEmpty = CollectionSectionViewModel(cellViewModels: [])
-        let section2 = CollectionSectionViewModel(cellViewModels: generateCollectionCellViewModels(count: 1))
+        let section0 = CollectionSectionViewModel(
+            diffingKey: nil,
+            cellViewModels: generateCollectionCellViewModels()
+        )
+        let sectionEmpty = CollectionSectionViewModel(diffingKey: nil, cellViewModels: [])
+        let section2 = CollectionSectionViewModel(
+            diffingKey: nil,
+            cellViewModels: generateCollectionCellViewModels(count: 1)
+        )
 
         let viewModel1 = CollectionViewModel(sectionModels: [])
         XCTAssertTrue(viewModel1.isEmpty)
@@ -102,6 +110,7 @@ final class CollectionViewModelTests: XCTestCase {
     /// Verify Collection conformace
     func testSectionCollection() {
         let section = CollectionSectionViewModel(
+            diffingKey: nil,
             cellViewModels: generateCollectionCellViewModels()
         )
         let sectionLabels = section.cellViewModels.compactMap {

--- a/Tests/TableView/TableViewDiffingTests.swift
+++ b/Tests/TableView/TableViewDiffingTests.swift
@@ -81,12 +81,12 @@ final class TableViewDiffingTests: XCTestCase {
     func testChangingSections() {
         let initialModel = TableViewModel(sectionModels: [
             TableSectionViewModel(
-                cellViewModels: generateTableCellViewModels(),
-                diffingKey: "1"
+                diffingKey: "1",
+                cellViewModels: generateTableCellViewModels()
             ),
             TableSectionViewModel(
-                cellViewModels: generateTableCellViewModels(),
-                diffingKey: "2"
+                diffingKey: "2",
+                cellViewModels: generateTableCellViewModels()
             ),
         ])
 
@@ -94,8 +94,8 @@ final class TableViewDiffingTests: XCTestCase {
 
         let updatedModel = TableViewModel(sectionModels: [
             TableSectionViewModel(
-                cellViewModels: generateTableCellViewModels(),
-                diffingKey: "2"
+                diffingKey: "2",
+                cellViewModels: generateTableCellViewModels()
             ),
         ])
 
@@ -108,23 +108,23 @@ final class TableViewDiffingTests: XCTestCase {
     func testChangingSectionsThatAreEmpty() {
         let initialModel = TableViewModel(sectionModels: [
             TableSectionViewModel(
-                cellViewModels: [],
-                diffingKey: "1"
+                diffingKey: "1",
+                cellViewModels: []
             ),
             TableSectionViewModel(
-                cellViewModels: [],
-                diffingKey: "2"
+                diffingKey: "2",
+                cellViewModels: []
             ),
-            ])
+        ])
 
         self.tableViewDataSource.tableViewModel = initialModel
 
         let updatedModel = TableViewModel(sectionModels: [
             TableSectionViewModel(
-                cellViewModels: [],
-                diffingKey: "2"
+                diffingKey: "2",
+                cellViewModels: []
             ),
-            ])
+        ])
 
         self.tableViewDataSource.tableViewModel = updatedModel
 

--- a/Tests/TableView/TableViewDriverTests.swift
+++ b/Tests/TableView/TableViewDriverTests.swift
@@ -36,14 +36,17 @@ final class TableViewDriverTests: XCTestCase {
     private func setupWithTableView(_ tableView: UITableView) {
         self._tableViewModel = TableViewModel(sectionModels: [
             TableSectionViewModel(
+                diffingKey: nil,
                 cellViewModels: [],
                 headerViewModel: TestHeaderFooterViewModel(height: 10, viewKind: .header, label: "A"),
                 footerViewModel: TestHeaderFooterViewModel(height: 11, viewKind: .footer, label: "A")),
             TableSectionViewModel(
+                diffingKey: nil,
                 cellViewModels: ["A", "B", "C"].map { _generateTestCellViewModel($0) },
                 headerViewModel: nil,
                 footerViewModel: TestHeaderFooterViewModel(title: "footer_2", height: 21)),
              TableSectionViewModel(
+                diffingKey: nil,
                 cellViewModels: ["D", "E", "F"].map { _generateTestCellViewModel($0) },
                 headerViewModel: TestHeaderFooterViewModel(title: "header_3", height: 30),
                 footerViewModel: nil),
@@ -283,10 +286,12 @@ private func _generateTestCellViewModel(_ label: String) -> TestCellViewModel {
 private func _generateTestTableViewModelForRefreshingViews() -> TableViewModel {
     return TableViewModel(sectionModels: [
         TableSectionViewModel(
+            diffingKey: nil,
             cellViewModels: [_generateTestCellViewModel("X")],
             headerViewModel: TestHeaderFooterViewModel(height: 10, viewKind: .header, label: "X"),
             footerViewModel: TestHeaderFooterViewModel(height: 11, viewKind: .footer, label: "X")),
         TableSectionViewModel(
+            diffingKey: nil,
             cellViewModels: ["Y", "Z"].map { _generateTestCellViewModel($0) },
             headerViewModel: TestHeaderFooterViewModel(height: 20, viewKind: .header, label: "Y"),
             footerViewModel: TestHeaderFooterViewModel(height: 21, viewKind: .footer, label: "Y")),

--- a/Tests/TableView/TableViewModelTests.swift
+++ b/Tests/TableView/TableViewModelTests.swift
@@ -25,17 +25,21 @@ final class TableViewModelTests: XCTestCase {
     func testSubscripts() {
         let tableViewModel = TableViewModel(sectionModels: [
             TableSectionViewModel(
+                diffingKey: nil,
                 headerTitle: "section_1",
                 headerHeight: 42,
-                cellViewModels: []),
+                cellViewModels: []
+            ),
             TableSectionViewModel(
+                diffingKey: nil,
                 headerTitle: "section_2",
                 headerHeight: 43,
                 cellViewModels: [
                     generateTestCellViewModel("A"),
                     generateTestCellViewModel("B"),
                     generateTestCellViewModel("C"),
-            ]),
+                ]
+            ),
         ])
 
         // Returns `nil` when there's no cell/section at the provided path.
@@ -52,9 +56,15 @@ final class TableViewModelTests: XCTestCase {
 
     /// The `.isEmpty` property of the table view.
     func testIsEmpty() {
-        let section0 = TableSectionViewModel(cellViewModels: generateTableCellViewModels())
-        let sectionEmpty = TableSectionViewModel(cellViewModels: [])
-        let section2 = TableSectionViewModel(cellViewModels: generateTableCellViewModels(count: 1))
+        let section0 = TableSectionViewModel(
+            diffingKey: nil,
+            cellViewModels: generateTableCellViewModels()
+        )
+        let sectionEmpty = TableSectionViewModel(diffingKey: nil, cellViewModels: [])
+        let section2 = TableSectionViewModel(
+            diffingKey: nil,
+            cellViewModels: generateTableCellViewModels(count: 1)
+        )
 
         let tableViewModel1 = TableViewModel(sectionModels: [])
         XCTAssertTrue(tableViewModel1.isEmpty)
@@ -79,6 +89,7 @@ final class TableViewModelTests: XCTestCase {
     /// using a plain section header.
     func testPlainHeaderFooterSectionModelInitalizer() {
         let sectionModel = TableSectionViewModel(
+            diffingKey: nil,
             headerTitle: "foo",
             headerHeight: 42,
             cellViewModels: [generateTestCellViewModel()],
@@ -99,6 +110,7 @@ final class TableViewModelTests: XCTestCase {
     /// using a custom section header type.
     func testCustomHeaderFooterSectionModelInitalizer() {
         let sectionModel = TableSectionViewModel(
+            diffingKey: nil,
             cellViewModels: [generateTestCellViewModel()],
             headerViewModel: TestHeaderFooterViewModel(height: 42, viewKind: .header, label: "A"),
             footerViewModel: TestHeaderFooterViewModel(height: 43, viewKind: .footer, label: "A"))
@@ -129,6 +141,7 @@ final class TableViewModelTests: XCTestCase {
     /// Verify Collection conformace
     func testSectionCollection() {
         let section = TableSectionViewModel(
+            diffingKey: nil,
             cellViewModels: generateTableCellViewModels()
         )
         let sectionLabels = section.cellViewModels.compactMap {


### PR DESCRIPTION
## Changes in this pull request

Issue fixed: n/a

As discussed with @benasher44 and @noahsark769, this updates the initializers for `TableSectionViewModel` and `CollectionSectionViewModel` so that the `diffingKey` argument is _required_. 

This prevents accidental misuse of the automatic diffing API, which is possible if you rely on the current default parameter value. 😅 

No new behavior here, just a breaking API change. Tests are updated accordingly (no new ones).

#### Note on the parameter positioning

Previously `diffingKey` was the **last** parameter in each initializer. I chose to make it the **first** in the argument list:
* The Swift [API design guidelines](https://swift.org/documentation/api-design-guidelines/) tell us:
> Prefer to locate parameters with defaults toward the end of the parameter list
* If we keep `diffingKey` close to the bottom as the last required parameter, it divides the required argument for the collection/table view models from the optional arguments for header and footer like so 🤮

```swift
TableSectionViewModel(
    cellViewModels: ...,
    diffingKey: nil,
    headerViewModel: ...,
    footerViewModel: ...
)
```

I like it at the beginning better because it kind of looks like a section name. Open to discussion if there are any objections, though!

### Checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I added tests, an experiment, or detailed why my change isn't tested.
- [X] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [X] I have reviewed the [contributing guide](https://github.com/plangrid/ReactiveLists/blob/master/.github/CONTRIBUTING.md)
