### PR TITLE
[Scout] Use allSatisfy()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ This release closes the [0.4.0 milestone](https://github.com/plangrid/ReactiveLi
 
 - Upgrades DifferenceKit to 0.7.2  ([#148](https://github.com/plangrid/ReactiveLists/pull/148), [@benasher44](https://github.com/benasher44)
 
+### Changed
+
+- Use `allSatisfy(_:)` in places where we would use `first(where:)` and a `nil` check
+
 0.3.0
 -----
 

--- a/Sources/CollectionViewModel.swift
+++ b/Sources/CollectionViewModel.swift
@@ -83,7 +83,7 @@ public struct CollectionViewModel {
 
     /// Returns `true` if this collection has all empty sections.
     public var isEmpty: Bool {
-        return self.sectionModels.first(where: { !$0.isEmpty }) == nil
+        return self.sectionModels.allSatisfy { $0.isEmpty }
     }
 
     /// Initializes a collection view model with the sections provided.

--- a/Sources/TableViewModel.swift
+++ b/Sources/TableViewModel.swift
@@ -218,7 +218,7 @@ public struct TableViewModel {
 
     /// Returns `true` if this table has all empty sections.
     public var isEmpty: Bool {
-        return self.sectionModels.first(where: { !$0.isEmpty }) == nil
+        return self.sectionModels.allSatisfy { $0.isEmpty }
     }
 
     /// Initializes a table view model with one section and the cell models provided


### PR DESCRIPTION
## Changes in this pull request

Uses allSatisfy() in places where
we would use first(where:) == nil


### Checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have reviewed the [contributing guide](https://github.com/plangrid/ReactiveLists/blob/master/.github/CONTRIBUTING.md)
