### PR TITLE
Add support for UISwipeActionsConfiguration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,12 @@ The changelog for `ReactiveLists`. Also see the [releases](https://github.com/pl
 NEXT
 ----
 
+## Breaking
+- Dropped support for the `UITableViewRowAction` API in the `TableViewCellModelEditActions`protocol, as `UITableViewRowAction` is deprecated in iOS 13. `TableViewCellModelEditActions` now uses the `UISwipeActionsConfiguration` API instead. ([#167](https://github.com/plangrid/ReactiveLists/pull/167), [@ronaldsmartin](https://github.com/ronaldsmartin))
+
 ### Changed
 - Upgrades SwiftLint to 0.31.0 and add several new rules. ([#164](https://github.com/plangrid/ReactiveLists/pull/164), [@anayini](https://github.com/anayini))
 - Upgrade Travis to Xcode 10.2, SDK 12.2
-- Add support for the `UISwipeActionsConfiguration` API, which replaces the deprecated `UITableViewRowAction` API, [@ronaldsmartin](https://github.com/ronaldsmartin)
 
 0.5.1
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ NEXT
 ### Changed
 - Upgrades SwiftLint to 0.31.0 and add several new rules. ([#164](https://github.com/plangrid/ReactiveLists/pull/164), [@anayini](https://github.com/anayini))
 - Upgrade Travis to Xcode 10.2, SDK 12.2
+- Add support for the `UISwipeActionsConfiguration` API, which replaces the deprecated `UITableViewRowAction` API, [@ronaldsmartin](https://github.com/ronaldsmartin)
 
 0.5.1
 -----

--- a/Sources/TableViewDriver.swift
+++ b/Sources/TableViewDriver.swift
@@ -300,14 +300,12 @@ extension TableViewDriver: UITableViewDelegate {
     }
 
     /// :nodoc:
-    @available(iOS 11.0, *)
     public func tableView(_ tableView: UITableView, leadingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
         guard let editActions = self.tableViewModel?[ifExists: indexPath] as? TableViewCellModelEditActions else { return nil }
         return editActions.leadingSwipeActionConfiguration
     }
 
     /// :nodoc:
-    @available(iOS 11.0, *)
     public func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
         guard let editActions = self.tableViewModel?[ifExists: indexPath] as? TableViewCellModelEditActions else { return nil }
         return editActions.trailingSwipeActionConfiguration

--- a/Sources/TableViewDriver.swift
+++ b/Sources/TableViewDriver.swift
@@ -314,14 +314,6 @@ extension TableViewDriver: UITableViewDelegate {
     }
 
     /// :nodoc:
-    public func tableView(_ tableView: UITableView, editActionsForRowAt indexPath: IndexPath) -> [UITableViewRowAction]? {
-        if let cellViewModel = self.tableViewModel?[ifExists: indexPath] as? TableViewCellModelEditActions {
-            return cellViewModel.editActions
-        }
-        return nil
-    }
-
-    /// :nodoc:
     public func tableView(_ tableView: UITableView, accessoryButtonTappedForRowWith indexPath: IndexPath) {
         self.tableViewModel?[ifExists: indexPath]?.accessoryButtonTapped?()
     }

--- a/Sources/TableViewDriver.swift
+++ b/Sources/TableViewDriver.swift
@@ -300,6 +300,20 @@ extension TableViewDriver: UITableViewDelegate {
     }
 
     /// :nodoc:
+    @available(iOS 11.0, *)
+    public func tableView(_ tableView: UITableView, leadingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
+        guard let editActions = self.tableViewModel?[ifExists: indexPath] as? TableViewCellModelEditActions else { return nil }
+        return editActions.leadingSwipeActionConfiguration
+    }
+
+    /// :nodoc:
+    @available(iOS 11.0, *)
+    public func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
+        guard let editActions = self.tableViewModel?[ifExists: indexPath] as? TableViewCellModelEditActions else { return nil }
+        return editActions.trailingSwipeActionConfiguration
+    }
+
+    /// :nodoc:
     public func tableView(_ tableView: UITableView, editActionsForRowAt indexPath: IndexPath) -> [UITableViewRowAction]? {
         if let cellViewModel = self.tableViewModel?[ifExists: indexPath] as? TableViewCellModelEditActions {
             return cellViewModel.editActions

--- a/Sources/TableViewModel.swift
+++ b/Sources/TableViewModel.swift
@@ -94,7 +94,16 @@ extension TableCellViewModel {
 /// that want to provide edit actions.
 public protocol TableViewCellModelEditActions {
 
+    /// The edit actions for this cell when swiping from the leading direction.
+    @available(iOS 11.0, *)
+    var leadingSwipeActionConfiguration: UISwipeActionsConfiguration? { get }
+
+    /// The edit actions for this cell when swiping from the trailing direction.
+    @available(iOS 11.0, *)
+    var trailingSwipeActionConfiguration: UISwipeActionsConfiguration? { get }
+
     /// The row edit actions for the cell.
+    /// - Warning: `UITableViewRowAction` is deprecated in iOS 13. Implement `leadingSwipeActionConfiguration` or `trailingSwipeActionConfiguration` instead.
     var editActions: [UITableViewRowAction] { get }
 }
 

--- a/Sources/TableViewModel.swift
+++ b/Sources/TableViewModel.swift
@@ -95,16 +95,20 @@ extension TableCellViewModel {
 public protocol TableViewCellModelEditActions {
 
     /// The edit actions for this cell when swiping from the leading direction.
-    @available(iOS 11.0, *)
     var leadingSwipeActionConfiguration: UISwipeActionsConfiguration? { get }
 
     /// The edit actions for this cell when swiping from the trailing direction.
-    @available(iOS 11.0, *)
     var trailingSwipeActionConfiguration: UISwipeActionsConfiguration? { get }
+}
 
-    /// The row edit actions for the cell.
-    /// - Warning: `UITableViewRowAction` is deprecated in iOS 13. Implement `leadingSwipeActionConfiguration` or `trailingSwipeActionConfiguration` instead.
-    var editActions: [UITableViewRowAction] { get }
+/// Default implementation for `TableViewCellModelEditActions`.
+extension TableViewCellModelEditActions {
+
+    /// Default implementation, returns `nil`.
+    var leadingSwipeActionConfiguration: UISwipeActionsConfiguration? { return nil }
+
+    /// Default implementation, returns `nil`.
+    var trailingSwipeActionConfiguration: UISwipeActionsConfiguration? { return nil }
 }
 
 /// Protocol that needs to be implemented by custom header


### PR DESCRIPTION
## Changes in this pull request
This adds tableview support for the [`UISwipeActionsConfiguration`](https://developer.apple.com/documentation/uikit/uiswipeactionsconfiguration) API, which was introduced in iOS 11. This should be used to replace usage of the `UITableViewRowAction` API, which will be deprecated in iOS 13.

Issue fixed: none

### Checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I added tests, an experiment, or detailed why my change isn't tested.
- [X] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [X] I have reviewed the [contributing guide](https://github.com/plangrid/ReactiveLists/blob/master/.github/CONTRIBUTING.md)