### PR TITLE
Make TableViewCellModelEditActions default implementations public

### DIFF
--- a/Sources/Diffing.swift
+++ b/Sources/Diffing.swift
@@ -42,7 +42,7 @@ extension DiffableViewModel {
     }
 }
 
-/// MARK: - DifferenceKit Helpers
+// MARK: - DifferenceKit Helpers
 
 /// Creates a type-erased Differentiable for DiffableViewModel.
 /// These are only created internally from either `TableCellViewModel` or `CollectionCellViewModel`,
@@ -91,7 +91,7 @@ extension AnyDiffableViewModel: Differentiable {
     }
 }
 
-/// MARK: - DifferenceKit Protocol Conformance
+// MARK: - DifferenceKit Protocol Conformance
 
 extension TableSectionViewModel: DifferentiableSection {
 

--- a/Sources/TableViewModel.swift
+++ b/Sources/TableViewModel.swift
@@ -105,10 +105,10 @@ public protocol TableViewCellModelEditActions {
 extension TableViewCellModelEditActions {
 
     /// Default implementation, returns `nil`.
-    var leadingSwipeActionConfiguration: UISwipeActionsConfiguration? { return nil }
+    public var leadingSwipeActionConfiguration: UISwipeActionsConfiguration? { return nil }
 
     /// Default implementation, returns `nil`.
-    var trailingSwipeActionConfiguration: UISwipeActionsConfiguration? { return nil }
+    public var trailingSwipeActionConfiguration: UISwipeActionsConfiguration? { return nil }
 }
 
 /// Protocol that needs to be implemented by custom header


### PR DESCRIPTION
## Changes in this pull request

In #167, I forgot to make the default implementations for the `TableViewCellModelEditActions` properties `public`. Thus, they were only the defaults within ReactiveLists.

Also, fixes a (new?) lint warning.

### Checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I added tests, an experiment, or detailed why my change isn't tested.
- [X] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [X] I have reviewed the [contributing guide](https://github.com/plangrid/ReactiveLists/blob/master/.github/CONTRIBUTING.md)
