### PR TITLE
Add support for individual UICollectionViewCell sizing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ NEXT
 - Dropped support for the `UITableViewRowAction` API in the `TableViewCellModelEditActions`protocol, as `UITableViewRowAction` is deprecated in iOS 13. `TableViewCellModelEditActions` now uses the `UISwipeActionsConfiguration` API instead. ([#167](https://github.com/plangrid/ReactiveLists/pull/167), [@ronaldsmartin](https://github.com/ronaldsmartin))
 
 ### Changed
+- Introduce the `itemSize` property to `CollectionCellViewModel` to add support for specifying unique item sizes for collection views used with `UICollectionViewFlowLayout`. ([#177](https://github.com/plangrid/ReactiveLists/pull/177), [@ronaldsmartin](https://github.com/ronaldsmartin))
 - Upgrades SwiftLint to 0.31.0 and add several new rules. ([#164](https://github.com/plangrid/ReactiveLists/pull/164), [@anayini](https://github.com/anayini))
 - Upgrade Travis to Xcode 10.2, SDK 12.2
 

--- a/Example/CollectionViewCells.swift
+++ b/Example/CollectionViewCells.swift
@@ -28,6 +28,7 @@ final class CollectionToolCellModel: CollectionCellViewModel, DiffableViewModel 
 
     let accessibilityFormat: CellAccessibilityFormat = "CollectionToolCell"
     let registrationInfo = ViewRegistrationInfo(classType: CollectionToolCell.self, nibName: "CollectionToolCell")
+    let itemSize: CGSize? = CGSize(width: 150, height: 100)
     let commitEditingStyle: CommitEditingStyleClosure?
     let editingStyle: UITableViewCell.EditingStyle = .delete
 

--- a/Sources/CollectionViewDriver.swift
+++ b/Sources/CollectionViewDriver.swift
@@ -248,6 +248,9 @@ extension CollectionViewDriver: UICollectionViewDelegate {
 }
 
 extension CollectionViewDriver: UICollectionViewDelegateFlowLayout {
+
+    // MARK: Supplementary view sizing
+
     /// :nodoc:
     public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {
         return self._sizeForSupplementaryViewOfKind(.header, inSection: section, collectionViewLayout: collectionViewLayout)
@@ -256,5 +259,21 @@ extension CollectionViewDriver: UICollectionViewDelegateFlowLayout {
     /// :nodoc:
     public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForFooterInSection section: Int) -> CGSize {
         return self._sizeForSupplementaryViewOfKind(.footer, inSection: section, collectionViewLayout: collectionViewLayout)
+    }
+
+    // MARK: Cell view sizing
+
+    /// :nodoc:
+    public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        if let itemSize = self.collectionViewModel?[ifExists: indexPath]?.itemSize {
+            return itemSize
+        }
+
+        guard let flowLayout = collectionViewLayout as? UICollectionViewFlowLayout else {
+            assertionFailure("A non-flow layout should not hit this delegate method")
+            return .zero
+        }
+
+        return flowLayout.itemSize
     }
 }

--- a/Sources/CollectionViewModel.swift
+++ b/Sources/CollectionViewModel.swift
@@ -22,6 +22,10 @@ public protocol CollectionCellViewModel: ReusableCellViewModelProtocol, Diffable
     /// `CollectionViewDriver` will automatically apply an `accessibilityIdentifier` to the cell based on this format
     var accessibilityFormat: CellAccessibilityFormat { get }
 
+    /// When using this cell inside of a `UICollectionViewFlowLayout`, this value will be used to
+    /// size this cell.
+    var itemSize: CGSize? { get }
+
     /// Whether or not this cell should be highlighted.
     var shouldHighlight: Bool { get }
 
@@ -39,6 +43,9 @@ public protocol CollectionCellViewModel: ReusableCellViewModelProtocol, Diffable
 
 /// Default implementations for `CollectionCellViewModel`.
 extension CollectionCellViewModel {
+
+    /// Default implementation, returns `nil`.
+    public var itemSize: CGSize? { nil }
 
     /// Default implementation, returns `true`.
     public var shouldHighlight: Bool { return true }

--- a/Tests/CollectionView/CollectionViewDriverTests.swift
+++ b/Tests/CollectionView/CollectionViewDriverTests.swift
@@ -47,7 +47,9 @@ final class CollectionViewDriverTests: XCTestCase {
             ),
             CollectionSectionViewModel(
                 diffingKey: nil,
-                cellViewModels: ["A", "B", "C"].map { self._generateTestCollectionCellViewModel($0) },
+                cellViewModels: ["A", "B", "C"].map {
+                    self._generateTestCollectionCellViewModel($0, itemSize: CGSize(width: 44, height: 44))
+                },
                 headerViewModel: nil,
                 footerViewModel: TestCollectionViewSupplementaryViewModel(label: "footer_B", height: 21)),
             CollectionSectionViewModel(
@@ -115,6 +117,38 @@ final class CollectionViewDriverTests: XCTestCase {
                                                                              layout: $0 ?? UICollectionViewLayout(),
                                                                              referenceSizeForFooterInSection: $1).height, $2)
         }
+    }
+
+    func testDefaultItemSize() {
+        let layout = UICollectionViewFlowLayout()
+        let section = 2
+        let firstViewModel = self._collectionViewDataSource
+            .collectionViewModel?
+            .sectionModels[section]
+            .cellViewModels[0]
+        let itemSize = self._collectionViewDataSource.collectionView(
+            self._collectionView,
+            layout: layout,
+            sizeForItemAt: path(section)
+        )
+        XCTAssertNil(firstViewModel?.itemSize)
+        XCTAssertEqual(itemSize, layout.itemSize)
+    }
+
+    func testExplicitItemSize() {
+        let layout = UICollectionViewFlowLayout()
+        let section = 1
+        let firstViewModel = self._collectionViewDataSource
+            .collectionViewModel?
+            .sectionModels[section]
+            .cellViewModels[0]
+        let itemSize = self._collectionViewDataSource.collectionView(
+            self._collectionView,
+            layout: layout,
+            sizeForItemAt: path(section)
+        )
+        XCTAssertEqual(itemSize, firstViewModel?.itemSize)
+        XCTAssertNotEqual(itemSize, layout.itemSize)
     }
 
     func testCollectionViewItems() {
@@ -254,6 +288,11 @@ final class CollectionViewDriverTests: XCTestCase {
         XCTAssertEqual(header?.accessibilityIdentifier, "access_header+0")
         XCTAssertEqual(footer?.accessibilityIdentifier, "access_footer+0")
     }
+}
+
+// MARK: - Test helpers
+
+extension CollectionViewDriverTests {
 
     private func _getItem(_ path: IndexPath) -> TestCollectionViewCell? {
         guard let cell = self._collectionViewDataSource.collectionView(self._collectionView,
@@ -271,8 +310,12 @@ final class CollectionViewDriverTests: XCTestCase {
         return view
     }
 
-    private func _generateTestCollectionCellViewModel(_ label: String) -> TestCollectionCellViewModel {
+    private func _generateTestCollectionCellViewModel(
+        _ label: String,
+        itemSize: CGSize? = nil
+    ) -> TestCollectionCellViewModel {
         return TestCollectionCellViewModel(label: label,
+                                           itemSize: itemSize,
                                            didSelect: { [weak self] in self?._lastSelectClosureCaller = label },
                                            didDeselect: { [weak self] in self?._lastDeselectClosureCaller = label })
     }

--- a/Tests/CollectionView/TestCollectionViewModels.swift
+++ b/Tests/CollectionView/TestCollectionViewModels.swift
@@ -19,6 +19,7 @@ import Foundation
 
 struct TestCollectionCellViewModel: CollectionCellViewModel {
     let label: String
+    let itemSize: CGSize?
     let didSelect: DidSelectClosure?
     let didDeselect: DidDeselectClosure?
 
@@ -93,6 +94,7 @@ class TestCollectionReusableView: UICollectionReusableView {
 
 func generateTestCollectionCellViewModel(_ label: String? = nil) -> TestCollectionCellViewModel {
     return TestCollectionCellViewModel(label: label ?? UUID().uuidString,
+                                       itemSize: nil,
                                        didSelect: nil,
                                        didDeselect: nil
     )
@@ -102,6 +104,7 @@ func generateCollectionCellViewModels(count: Int = 4) -> [CollectionCellViewMode
     var models = [TestCollectionCellViewModel]()
     for _ in 0..<count {
         models.append(TestCollectionCellViewModel(label: UUID().uuidString,
+                                                  itemSize: nil,
                                                   didSelect: nil,
                                                   didDeselect: nil))
     }


### PR DESCRIPTION
## Changes in this pull request

Issue fixed: #49

This introduces a new property `itemSize` to `CollectionCellViewModel` so that individual cells can be sized when collection views are used with flow layouts. Semantics mirror the equivalent `rowHeight` property used for `TableCellViewModel`.

### Checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have reviewed the [contributing guide](https://github.com/plangrid/ReactiveLists/blob/master/.github/CONTRIBUTING.md)
