### PR TITLE
Incorporate FlowLayout delegate params into collection cell itemSize API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ NEXT
 - Dropped support for the `UITableViewRowAction` API in the `TableViewCellModelEditActions`protocol, as `UITableViewRowAction` is deprecated in iOS 13. `TableViewCellModelEditActions` now uses the `UISwipeActionsConfiguration` API instead. ([#167](https://github.com/plangrid/ReactiveLists/pull/167), [@ronaldsmartin](https://github.com/ronaldsmartin))
 
 ### Changed
-- Introduce the `itemSize` property to `CollectionCellViewModel` to add support for specifying unique item sizes for collection views used with `UICollectionViewFlowLayout`. ([#177](https://github.com/plangrid/ReactiveLists/pull/177), [@ronaldsmartin](https://github.com/ronaldsmartin))
+- Introduce the `FlowLayoutCollectionCellViewModel` protocol to add support for specifying unique item sizes for collection views used with `UICollectionViewFlowLayout`. ([#178](https://github.com/plangrid/ReactiveLists/pull/177), [@ronaldsmartin](https://github.com/ronaldsmartin))
 - Upgrades SwiftLint to 0.31.0 and add several new rules. ([#164](https://github.com/plangrid/ReactiveLists/pull/164), [@anayini](https://github.com/anayini))
 - Upgrade Travis to Xcode 10.2, SDK 12.2
 

--- a/Sources/CollectionViewDriver.swift
+++ b/Sources/CollectionViewDriver.swift
@@ -265,13 +265,13 @@ extension CollectionViewDriver: UICollectionViewDelegateFlowLayout {
 
     /// :nodoc:
     public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        if let itemSize = self.collectionViewModel?[ifExists: indexPath]?.itemSize {
-            return itemSize
-        }
-
         guard let flowLayout = collectionViewLayout as? UICollectionViewFlowLayout else {
             assertionFailure("A non-flow layout should not hit this delegate method")
             return .zero
+        }
+
+        if let item = self.collectionViewModel?[ifExists: indexPath] as? FlowLayoutCollectionCellViewModel {
+            return item.itemSize(in: collectionView, layout: flowLayout, indexPath: indexPath)
         }
 
         return flowLayout.itemSize

--- a/Sources/CollectionViewModel.swift
+++ b/Sources/CollectionViewModel.swift
@@ -16,15 +16,13 @@
 
 import UIKit
 
+// MARK: - CollectionCellViewModel
+
 /// View model for the individual cells of a `UICollectionView`.
 public protocol CollectionCellViewModel: ReusableCellViewModelProtocol, DiffableViewModel {
 
     /// `CollectionViewDriver` will automatically apply an `accessibilityIdentifier` to the cell based on this format
     var accessibilityFormat: CellAccessibilityFormat { get }
-
-    /// When using this cell inside of a `UICollectionViewFlowLayout`, this value will be used to
-    /// size this cell.
-    var itemSize: CGSize? { get }
 
     /// Whether or not this cell should be highlighted.
     var shouldHighlight: Bool { get }
@@ -44,9 +42,6 @@ public protocol CollectionCellViewModel: ReusableCellViewModelProtocol, Diffable
 /// Default implementations for `CollectionCellViewModel`.
 extension CollectionCellViewModel {
 
-    /// Default implementation, returns `nil`.
-    public var itemSize: CGSize? { nil }
-
     /// Default implementation, returns `true`.
     public var shouldHighlight: Bool { return true }
 
@@ -56,6 +51,29 @@ extension CollectionCellViewModel {
     /// Default implementation, returns `nil`.
     public var didDeselect: DidDeselectClosure? { return nil }
 }
+
+/// A `FlowLayoutCollectionCellViewModel` is a `CollectionCellViewModel` that will be placed in its
+/// collection view using a `UICollectionViewFlowLayout`. This allows it to provide a dynamic item
+/// size that can take into account its container size and other layout information.
+public protocol FlowLayoutCollectionCellViewModel: CollectionCellViewModel {
+
+    /// When using this cell inside of a `UICollectionViewFlowLayout`, this hook can be used to
+    /// size this cell.
+    ///
+    /// - Parameters:
+    ///   - collectionView: The parent `UICollectionView` of this cell.
+    ///   - layout: The `UICollectionViewFlowLayout` that will layout this cell.
+    ///   - indexPath: The path at which this item is positioned in `collectionView`.
+    /// - Returns:
+    ///   The width and height of the specified item. Both values should be greater than 0.
+    func itemSize(
+        in collectionView: UICollectionView,
+        layout: UICollectionViewFlowLayout,
+        indexPath: IndexPath
+    ) -> CGSize
+}
+
+// MARK: - CollectionSupplementaryViewModel
 
 /// View model for supplementary views in collection views.
 public protocol CollectionSupplementaryViewModel: ReusableSupplementaryViewModelProtocol {
@@ -81,6 +99,8 @@ extension CollectionSupplementaryViewModel {
     /// Default implementation, returns `nil`.
     public var height: CGFloat? { return nil }
 }
+
+// MARK: - CollectionViewModel
 
 /// The view model that describes a `UICollectionView`.
 public struct CollectionViewModel {
@@ -116,6 +136,8 @@ public struct CollectionViewModel {
         return section.cellViewModels[indexPath.item]
     }
 }
+
+// MARK: - CollectionSectionViewModel
 
 /// View model for a collection view section.
 public struct CollectionSectionViewModel: DiffableViewModel {

--- a/Tests/CollectionView/CollectionViewDriverTests.swift
+++ b/Tests/CollectionView/CollectionViewDriverTests.swift
@@ -131,7 +131,7 @@ final class CollectionViewDriverTests: XCTestCase {
             layout: layout,
             sizeForItemAt: path(section)
         )
-        XCTAssertNil(firstViewModel?.itemSize)
+        XCTAssertFalse(firstViewModel is FlowLayoutCollectionCellViewModel)
         XCTAssertEqual(itemSize, layout.itemSize)
     }
 
@@ -141,13 +141,18 @@ final class CollectionViewDriverTests: XCTestCase {
         let firstViewModel = self._collectionViewDataSource
             .collectionViewModel?
             .sectionModels[section]
-            .cellViewModels[0]
+            .cellViewModels[0] as? FlowLayoutCollectionCellViewModel
+        let indexPath = path(section)
         let itemSize = self._collectionViewDataSource.collectionView(
             self._collectionView,
             layout: layout,
-            sizeForItemAt: path(section)
+            sizeForItemAt: indexPath
         )
-        XCTAssertEqual(itemSize, firstViewModel?.itemSize)
+        XCTAssertNotNil(firstViewModel)
+        XCTAssertEqual(
+            itemSize,
+            firstViewModel!.itemSize(in: self._collectionView, layout: layout, indexPath: indexPath)
+        )
         XCTAssertNotEqual(itemSize, layout.itemSize)
     }
 
@@ -313,9 +318,16 @@ extension CollectionViewDriverTests {
     private func _generateTestCollectionCellViewModel(
         _ label: String,
         itemSize: CGSize? = nil
-    ) -> TestCollectionCellViewModel {
+    ) -> CollectionCellViewModel {
+        if let itemSize = itemSize {
+            return TestFlowLayoutCollectionCellViewModel(
+                label: label,
+                itemSize: itemSize,
+                didSelect: { [weak self] in self?._lastSelectClosureCaller = label },
+                didDeselect: { [weak self] in self?._lastDeselectClosureCaller = label }
+            )
+        }
         return TestCollectionCellViewModel(label: label,
-                                           itemSize: itemSize,
                                            didSelect: { [weak self] in self?._lastSelectClosureCaller = label },
                                            didDeselect: { [weak self] in self?._lastDeselectClosureCaller = label })
     }

--- a/Tests/CollectionView/TestCollectionViewModels.swift
+++ b/Tests/CollectionView/TestCollectionViewModels.swift
@@ -19,7 +19,6 @@ import Foundation
 
 struct TestCollectionCellViewModel: CollectionCellViewModel {
     let label: String
-    let itemSize: CGSize?
     let didSelect: DidSelectClosure?
     let didDeselect: DidDeselectClosure?
 
@@ -34,6 +33,34 @@ struct TestCollectionCellViewModel: CollectionCellViewModel {
     func applyViewModelToCell(_ cell: UICollectionViewCell) {
         guard let testCell = cell as? TestCollectionViewCell else { return }
         testCell.label = self.label
+    }
+}
+
+struct TestFlowLayoutCollectionCellViewModel: FlowLayoutCollectionCellViewModel {
+    let label: String
+    let itemSize: CGSize
+    let didSelect: DidSelectClosure?
+    let didDeselect: DidDeselectClosure?
+
+    let registrationInfo = ViewRegistrationInfo(classType: TestCollectionViewCell.self)
+    let accessibilityFormat: CellAccessibilityFormat = "access-%{section}.%{row}"
+    let shouldHighlight = false
+
+    var diffingKey: DiffingKey {
+        return self.label
+    }
+
+    func applyViewModelToCell(_ cell: UICollectionViewCell) {
+        guard let testCell = cell as? TestCollectionViewCell else { return }
+        testCell.label = self.label
+    }
+
+    func itemSize(
+        in collectionView: UICollectionView,
+        layout: UICollectionViewFlowLayout,
+        indexPath: IndexPath
+    ) -> CGSize {
+        self.itemSize
     }
 }
 
@@ -94,7 +121,6 @@ class TestCollectionReusableView: UICollectionReusableView {
 
 func generateTestCollectionCellViewModel(_ label: String? = nil) -> TestCollectionCellViewModel {
     return TestCollectionCellViewModel(label: label ?? UUID().uuidString,
-                                       itemSize: nil,
                                        didSelect: nil,
                                        didDeselect: nil
     )
@@ -104,7 +130,6 @@ func generateCollectionCellViewModels(count: Int = 4) -> [CollectionCellViewMode
     var models = [TestCollectionCellViewModel]()
     for _ in 0..<count {
         models.append(TestCollectionCellViewModel(label: UUID().uuidString,
-                                                  itemSize: nil,
                                                   didSelect: nil,
                                                   didDeselect: nil))
     }


### PR DESCRIPTION
## Changes in this pull request

This replaces `CollectionCellViewModel.itemSize` with a new protocol, `FlowLayoutCollectionCellViewModel`.

#177 was a naive first attempt at implementing #49. However, I was thinking through actual usage of this API (also was inspired by #54), and I think in most situations it would be helpful to have access to the collection view and layout objects when specifying a cell size (users can just ignore the view and layout if unneeded). Those params are already passed into the `UICollectionViewDelegateFlowLayout` method where `itemSize` is used, so it's easy to expose access to ReactiveLists clients.

Additionally, `itemSize` is only actually useful if a collection view is used with `UICollectionViewFlowLayout`. Making this explicit with a different protocol will be clearer than having a property that only works sometimes.

### Checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have reviewed the [contributing guide](https://github.com/plangrid/ReactiveLists/blob/master/.github/CONTRIBUTING.md)
