### PR TITLE
Add a CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# review_type: Random
+* @plangrid/ios-developers


### PR DESCRIPTION
## Changes in this pull request

Adds a CODEOWNERS file to enable automatic PR review assignment. See the [GitHub CODEOWNERS docs](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners ) for more details.

Note: `review-type` is a Hera-specific syntax

Issue fixed: None

### Checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have reviewed the [contributing guide](https://github.com/plangrid/ReactiveLists/blob/master/.github/CONTRIBUTING.md)
