### PR TITLE
Improve datasource caching

### DIFF
--- a/ReactiveLists.podspec
+++ b/ReactiveLists.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = "ReactiveLists"
-  s.version = "0.8.0.alpha.3"
+  s.version = "0.8.0.alpha.4"
 
   s.summary = "React-like API for UITableView and UICollectionView"
   s.homepage = "https://github.com/plangrid/ReactiveLists"

--- a/Sources/Diffing.swift
+++ b/Sources/Diffing.swift
@@ -216,6 +216,8 @@ struct DiffableTableSectionViewModel: Collection, DifferentiableSection {
     init(sectionModel: TableSectionViewModel, visibleIndices: Set<Int>) {
         self._sectionModel = sectionModel
         self._visibleIndices = visibleIndices
+        self.startIndex = sectionModel.startIndex
+        self.endIndex = sectionModel.endIndex
     }
 
     // MARK: - Protocol Implementations
@@ -228,12 +230,17 @@ struct DiffableTableSectionViewModel: Collection, DifferentiableSection {
                 // this will always be used for tables, and
                 // cell models have to be of type TableCellViewModel
                 //swiftlint:disable:next force_cast
-                elements.map { $0.model as! TableCellViewModel }
+                elements.map { $0.model as! TableCellViewModel },
+                // pass through the already-calculated cell registration
+                // info to avoid accidental eager loading of cell models
+                cellRegistrationInfo: source._sectionModel.cellViewModelDataSource.cellRegistrationInfo
             ),
             headerViewModel: source._sectionModel.headerViewModel,
             footerViewModel: source._sectionModel.footerViewModel
         )
         self._visibleIndices = source._visibleIndices
+        self.startIndex = source._sectionModel.startIndex
+        self.endIndex = source._sectionModel.endIndex
     }
 
     /// :nodoc:
@@ -263,10 +270,10 @@ struct DiffableTableSectionViewModel: Collection, DifferentiableSection {
     typealias Index = Int
 
     /// :nodoc:
-    var startIndex: Int { self._sectionModel.startIndex }
+    let startIndex: Int
 
     /// :nodoc:
-    var endIndex: Int { self._sectionModel.endIndex }
+    let endIndex: Int
 
     /// :nodoc:
     subscript(position: Int) -> AnyDiffableViewModel {

--- a/Sources/TableCellViewModelDataSource.swift
+++ b/Sources/TableCellViewModelDataSource.swift
@@ -46,12 +46,6 @@ public struct TableCellViewModelDataSource: RandomAccessCollection {
     private let _subscriptBlock: (Int) -> TableCellViewModel
 
     /// :nodoc:
-    private let _startIndexBlock: () -> Int
-
-    /// :nodoc:
-    private let _endIndexBlock: () -> Int
-
-    /// :nodoc:
     private let _prefetchBlock: (AnySequence<Int>) -> Void
 
     /// :nodoc:
@@ -59,12 +53,18 @@ public struct TableCellViewModelDataSource: RandomAccessCollection {
 
     /// Initializes the `TableCellViewModelDataSource` with the provided `TableCellViewModelDataSourceProtocol` implementation
     public init<DataSource: TableCellViewModelDataSourceProtocol>(_ dataSource: DataSource) {
+        self.init(dataSource, cellRegistrationInfo: dataSource.cellRegistrationInfo)
+    }
+
+    /// Used internally by the public init and during diffing
+    /// when cached ``ViewRegistrationInfo` is available
+    init<DataSource: TableCellViewModelDataSourceProtocol>(_ dataSource: DataSource, cellRegistrationInfo: [ViewRegistrationInfo]) {
         self._prefetchBlock = dataSource.prefetchRowsAt
         self._prefetchCancelBlock = dataSource.cancelPrefetchingRowsAt
         self._subscriptBlock = { dataSource[$0] }
-        self._startIndexBlock = { dataSource.startIndex }
-        self._endIndexBlock = { dataSource.endIndex }
-        self.cellRegistrationInfo = dataSource.cellRegistrationInfo
+        self.startIndex = dataSource.startIndex
+        self.endIndex = dataSource.endIndex
+        self.cellRegistrationInfo = cellRegistrationInfo
     }
 
     // MARK: - Protocol Implementation
@@ -92,10 +92,10 @@ public struct TableCellViewModelDataSource: RandomAccessCollection {
     }
 
     /// :nodoc:
-    public var startIndex: Int { self._startIndexBlock() }
+    public let startIndex: Int
 
     /// :nodoc:
-    public var endIndex: Int { self._endIndexBlock() }
+    public let endIndex: Int
 }
 
 extension Array: TableCellViewModelDataSourceProtocol where Element == TableCellViewModel {


### PR DESCRIPTION
## Changes in this pull request

- Cache view registration info across diffs
- Cache startIndex and endIndex to avoid re-querying original data source for count

### Checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have reviewed the [contributing guide](https://github.com/plangrid/ReactiveLists/blob/master/.github/CONTRIBUTING.md)
