### PR TITLE
Fixed diffing keys issue

### DIFF
--- a/ReactiveLists.podspec
+++ b/ReactiveLists.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = "ReactiveLists"
-  s.version = "0.8.1.beta.4"
+  s.version = "0.8.1.beta.5"
 
   s.summary = "React-like API for UITableView and UICollectionView"
   s.homepage = "https://github.com/plangrid/ReactiveLists"

--- a/Sources/Diffing.swift
+++ b/Sources/Diffing.swift
@@ -159,7 +159,7 @@ private final class DiffableTableCellViewModelProxy: TableCellViewModel {
     /// There is a scenario where some models that are off screen, are about to come on screen, and when they all share a diffing key
     /// they get mixed up and the StagedChangeset ends up with some unnecessary information.
     /// This was ok on Xcode 12, the DifferenceKit reload, which does a performBatchUpdate, sets the new table data, and modifies the rows, handled the extra info.
-    /// On upgrading to Xcode 13 the extra information in the StagedChangeset caused the performBatchUpdates to associated some cells with the wrong model.
+    /// On upgrading to Xcode 13 the extra information in the StagedChangeset caused the performBatchUpdates to associate some cells with the wrong model.
     private lazy var placeholderDiffingKey = UUID().uuidString
 
     /// When true, we allow diffing to access the real model's diffing key, eagerly loading it

--- a/Sources/Diffing.swift
+++ b/Sources/Diffing.swift
@@ -155,8 +155,12 @@ extension CollectionSectionViewModel: DifferentiableSection {
 /// which the data source may not have loaded
 private final class DiffableTableCellViewModelProxy: TableCellViewModel {
 
-    /// Static diffing key used when diffing off-screen models
-    private static let placeholderDiffingKey = UUID().uuidString
+    /// Changed from static to instance because it was giving all off screen models the same diffing key.
+    /// There is a scenario where some models that are off screen, are about to come on screen, and when they all share a diffing key
+    /// they get mixed up and the StagedChangeset ends up with some unnecessary information.
+    /// This was ok on Xcode 12, the DifferenceKit reload, which does a performBatchUpdate, sets the new table data, and modifies the rows, handled the extra info.
+    /// On upgrading to Xcode 13 the extra information in the StagedChangeset caused the performBatchUpdates to associated some cells with the wrong model.
+    private lazy var placeholderDiffingKey = UUID().uuidString
 
     /// When true, we allow diffing to access the real model's diffing key, eagerly loading it
     private let _inVisibleBounds: Bool
@@ -197,7 +201,7 @@ private final class DiffableTableCellViewModelProxy: TableCellViewModel {
         if self._inVisibleBounds {
             return self.model.diffingKey
         } else {
-            return Self.placeholderDiffingKey
+            return self.placeholderDiffingKey
         }
     }
 }


### PR DESCRIPTION
Fixed a diffing key issue inside DiffableTableCellViewModelProxy.

Changed from static to instance because it was giving all off screen models the same diffing key.
There is a scenario where some models that are off screen, are about to come on screen, and when they all share a diffing key they get mixed up and the StagedChangeset ends up with some unnecessary information.
This was ok on Xcode 12, the DifferenceKit reload, which does a performBatchUpdate, sets the new table data, and modifies the rows, handled the extra info.
On upgrading to Xcode 13 the extra information in the StagedChangeset caused the performBatchUpdates to associate some cells with the wrong model.

In PlanGrid, on Xcode 13, the wrong cells associated with wrong models could cause a crash. On Xcode 12, the crash part did not happen, but you could see an incorrect animation when new cells were presented on screen. Sometimes, one or more of the new cells would appear to come from somewhere else in the table, even though it was a unique new cell that did not share a reuse identifier with anything else in the table. This was because the extra information in the change set placed the new cell in a wrong position due to it having a common diffing key, then moving it to the right spot. 