### PR TITLE
Add ScrollViewDelegate conformance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,11 +15,11 @@ jobs:
     runs-on: macOS-latest
     strategy:
       matrix:
-        destination: ["OS=14.5,name=iPhone 11"]
+        destination: ["OS=15.0,name=iPhone 13"]
     steps:
       - uses: actions/checkout@v1
       - name: Select Xcode version
-        run: sudo xcode-select -s '/Applications/Xcode_12.5.1.app/Contents/Developer'
+        run: sudo xcode-select -s '/Applications/Xcode_14.2.app/Contents/Developer'
       - name: Bundle Install
         run: bundle install
       - uses: actions/cache@v1

--- a/ReactiveLists.podspec
+++ b/ReactiveLists.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = "ReactiveLists"
-  s.version = "0.8.1.beta.6"
+  s.version = "0.8.1.beta.7"
 
   s.summary = "React-like API for UITableView and UICollectionView"
   s.homepage = "https://github.com/plangrid/ReactiveLists"

--- a/Sources/TableViewDriver.swift
+++ b/Sources/TableViewDriver.swift
@@ -414,3 +414,11 @@ extension TableViewDriver: UITableViewDelegate {
         return self.tableViewModel?[ifExists: indexPath]?.shouldHighlight ?? true
     }
 }
+
+extension TableViewDriver: UIScrollViewDelegate {
+    /// :nodoc:
+    public func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        guard let tableViewModel = tableViewModel else { return }
+        tableViewModel.didScrollClosure?(scrollView)
+    }
+}

--- a/Sources/TableViewModel.swift
+++ b/Sources/TableViewModel.swift
@@ -348,6 +348,7 @@ public struct TableViewModel {
     /// - Parameters:
     ///   - sectionModels: the sections that need to be shown in this table view.
     ///   - sectionIndexTitles: the section index titles for this table view.
+    ///   - didScrollClosure: the scroll closure for this table view.
     public init(sectionModels: [TableSectionViewModel], sectionIndexTitles: [String]? = nil, defaultRowHeight: CGFloat = 44.0, didScrollClosure: DidScrollClosure? = nil) {
         self.sectionModels = sectionModels
         self.sectionIndexTitles = sectionIndexTitles

--- a/Sources/TableViewModel.swift
+++ b/Sources/TableViewModel.swift
@@ -327,16 +327,19 @@ public struct TableViewModel {
         return self.sectionModels.allSatisfy { $0.isEmpty }
     }
 
+    /// Invoked when the tableview is scrolled
+    public var didScrollClosure: DidScrollClosure?
+
     /// Initializes a table view model with one section and the cell models provided
     /// via the initializer.
     ///
     /// - Parameter cellViewModels: the cell models for the only section in this table.
-    public init(cellViewModels: [TableCellViewModel]) {
+    public init(cellViewModels: [TableCellViewModel], didScrollClosure: DidScrollClosure? = nil) {
         let section = TableSectionViewModel(
             diffingKey: "default_section",
             cellViewModels: cellViewModels
         )
-        self.init(sectionModels: [section])
+        self.init(sectionModels: [section], didScrollClosure: didScrollClosure)
     }
 
     /// Initializes a table view model with the sections provided.
@@ -345,10 +348,11 @@ public struct TableViewModel {
     /// - Parameters:
     ///   - sectionModels: the sections that need to be shown in this table view.
     ///   - sectionIndexTitles: the section index titles for this table view.
-    public init(sectionModels: [TableSectionViewModel], sectionIndexTitles: [String]? = nil, defaultRowHeight: CGFloat = 44.0) {
+    public init(sectionModels: [TableSectionViewModel], sectionIndexTitles: [String]? = nil, defaultRowHeight: CGFloat = 44.0, didScrollClosure: DidScrollClosure? = nil) {
         self.sectionModels = sectionModels
         self.sectionIndexTitles = sectionIndexTitles
         self.defaultRowHeight = defaultRowHeight
+        self.didScrollClosure = didScrollClosure
     }
 
     /// Returns the section model at the specified index or `nil` if no such section exists.

--- a/Sources/Typealiases.swift
+++ b/Sources/Typealiases.swift
@@ -30,3 +30,5 @@ public typealias WillBeginEditingClosure = () -> Void
 public typealias DidEndEditingClosure = () -> Void
 /// :nodoc:
 public typealias AccessoryButtonTappedClosure = () -> Void
+/// :nodoc:
+public typealias DidScrollClosure = (UIScrollView) -> Void


### PR DESCRIPTION
Currently when using the tableview driver it is not possible to handle scroll related events, so in this PR I am adding the conformance for the UIScrollViewDelegate protocol and a closure for the didScroll method only. The other methods are not considered for now.