### PR TITLE
Create datasource for cells to make lazy-loading possible for collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The changelog for `ReactiveLists`. Also see the [releases](https://github.com/pl
 
 NEXT
 ----
+0.8.1.8
+-----
+- Added support for CollectionView cells lazy-loading.
+
 0.8.1
 -----
 - Added support for deselect and willDispaly cells.

--- a/ReactiveLists.podspec
+++ b/ReactiveLists.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = "ReactiveLists"
-  s.version = "0.8.1.beta.7"
+  s.version = "0.8.1.beta.8"
 
   s.summary = "React-like API for UITableView and UICollectionView"
   s.homepage = "https://github.com/plangrid/ReactiveLists"

--- a/ReactiveLists.xcodeproj/project.pbxproj
+++ b/ReactiveLists.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		357B96DC2019374E0000443F /* CollectionToolCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 357B96D9201934C50000443F /* CollectionToolCell.xib */; };
 		357B96E9201956760000443F /* CollectionViewHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 357B96E8201956760000443F /* CollectionViewHeaderView.xib */; };
 		357B96EA2019599C0000443F /* CollectionViewHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 357B96E8201956760000443F /* CollectionViewHeaderView.xib */; };
+		39A211882A5342EE00288547 /* CollectionCellViewModelDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39A211872A5342EE00288547 /* CollectionCellViewModelDataSource.swift */; };
 		7C24B1408A8B3A147C254BCA /* Pods_ReactiveLists.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 978763204EC113AFD1F7EB54 /* Pods_ReactiveLists.framework */; };
 		A8069332250046AD0036CA11 /* TableViewLazyDiffingTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8069330250042700036CA11 /* TableViewLazyDiffingTest.swift */; };
 		A8D93CAA24FD9BDF00459EBB /* TableCellViewModelDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8D93CA924FD9BDF00459EBB /* TableCellViewModelDataSource.swift */; };
@@ -132,6 +133,7 @@
 		351B0BB420168D2E0034569D /* CollectionViewCells.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CollectionViewCells.swift; sourceTree = "<group>"; };
 		357B96D9201934C50000443F /* CollectionToolCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CollectionToolCell.xib; sourceTree = "<group>"; };
 		357B96E8201956760000443F /* CollectionViewHeaderView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CollectionViewHeaderView.xib; sourceTree = "<group>"; };
+		39A211872A5342EE00288547 /* CollectionCellViewModelDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionCellViewModelDataSource.swift; sourceTree = "<group>"; };
 		42A9724B45F9E14DD1B210D1 /* Pods-ReactiveLists.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ReactiveLists.release.xcconfig"; path = "Pods/Target Support Files/Pods-ReactiveLists/Pods-ReactiveLists.release.xcconfig"; sourceTree = "<group>"; };
 		45132CB591F9F96746AF8E96 /* Pods-ReactiveListsTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ReactiveListsTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-ReactiveListsTests/Pods-ReactiveListsTests.debug.xcconfig"; sourceTree = "<group>"; };
 		932473A2DAECE0F923C4B570 /* Pods_ReactiveListsTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ReactiveListsTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -279,6 +281,7 @@
 				32753F8C201BB8310084DCB1 /* UICollectionView+Extensions.swift */,
 				32753F8E201BB8470084DCB1 /* UITableView+Extensions.swift */,
 				32E7A1F7201BADE800B90EBC /* ViewRegistrationInfo.swift */,
+				39A211872A5342EE00288547 /* CollectionCellViewModelDataSource.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -395,6 +398,7 @@
 				TargetAttributes = {
 					2576640A1F29075C00C037E3 = {
 						CreatedOnToolsVersion = 8.3.3;
+						DevelopmentTeam = 29VP5K5AJ7;
 						LastSwiftMigration = 1000;
 						ProvisioningStyle = Automatic;
 					};
@@ -612,6 +616,7 @@
 				32E7A1F8201BADE800B90EBC /* ViewRegistrationInfo.swift in Sources */,
 				258E31B11F0D8D9C00D6F324 /* CollectionViewDriver.swift in Sources */,
 				258E31B41F0D8D9C00D6F324 /* TableViewModel.swift in Sources */,
+				39A211882A5342EE00288547 /* CollectionCellViewModelDataSource.swift in Sources */,
 				258E31D31F0D8F3100D6F324 /* AccessibilityFormats.swift in Sources */,
 				32753F8F201BB8470084DCB1 /* UITableView+Extensions.swift in Sources */,
 				A8D93CAA24FD9BDF00459EBB /* TableCellViewModelDataSource.swift in Sources */,
@@ -685,7 +690,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 29VP5K5AJ7;
 				INFOPLIST_FILE = "$(SRCROOT)/Example/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.plangrid.ReactiveListsExample;
@@ -701,7 +706,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 29VP5K5AJ7;
 				INFOPLIST_FILE = "$(SRCROOT)/Example/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.plangrid.ReactiveListsExample;

--- a/ReactiveLists.xcodeproj/project.pbxproj
+++ b/ReactiveLists.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		357B96E9201956760000443F /* CollectionViewHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 357B96E8201956760000443F /* CollectionViewHeaderView.xib */; };
 		357B96EA2019599C0000443F /* CollectionViewHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 357B96E8201956760000443F /* CollectionViewHeaderView.xib */; };
 		39A211882A5342EE00288547 /* CollectionCellViewModelDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39A211872A5342EE00288547 /* CollectionCellViewModelDataSource.swift */; };
+		39D64C592A54E4DB0071A7F3 /* CollectionViewLazyDiffingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39D64C582A54E4DB0071A7F3 /* CollectionViewLazyDiffingTests.swift */; };
 		7C24B1408A8B3A147C254BCA /* Pods_ReactiveLists.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 978763204EC113AFD1F7EB54 /* Pods_ReactiveLists.framework */; };
 		A8069332250046AD0036CA11 /* TableViewLazyDiffingTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8069330250042700036CA11 /* TableViewLazyDiffingTest.swift */; };
 		A8D93CAA24FD9BDF00459EBB /* TableCellViewModelDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8D93CA924FD9BDF00459EBB /* TableCellViewModelDataSource.swift */; };
@@ -134,6 +135,7 @@
 		357B96D9201934C50000443F /* CollectionToolCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CollectionToolCell.xib; sourceTree = "<group>"; };
 		357B96E8201956760000443F /* CollectionViewHeaderView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CollectionViewHeaderView.xib; sourceTree = "<group>"; };
 		39A211872A5342EE00288547 /* CollectionCellViewModelDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionCellViewModelDataSource.swift; sourceTree = "<group>"; };
+		39D64C582A54E4DB0071A7F3 /* CollectionViewLazyDiffingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionViewLazyDiffingTests.swift; sourceTree = "<group>"; };
 		42A9724B45F9E14DD1B210D1 /* Pods-ReactiveLists.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ReactiveLists.release.xcconfig"; path = "Pods/Target Support Files/Pods-ReactiveLists/Pods-ReactiveLists.release.xcconfig"; sourceTree = "<group>"; };
 		45132CB591F9F96746AF8E96 /* Pods-ReactiveListsTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ReactiveListsTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-ReactiveListsTests/Pods-ReactiveListsTests.debug.xcconfig"; sourceTree = "<group>"; };
 		932473A2DAECE0F923C4B570 /* Pods_ReactiveListsTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ReactiveListsTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -228,6 +230,7 @@
 				257A97DB2017AA3500164403 /* CollectionViewMocks.swift */,
 				257A97CA2017A80B00164403 /* CollectionViewModelTests.swift */,
 				257A97BC2017A5AA00164403 /* TestCollectionViewModels.swift */,
+				39D64C582A54E4DB0071A7F3 /* CollectionViewLazyDiffingTests.swift */,
 			);
 			path = CollectionView;
 			sourceTree = "<group>";
@@ -636,6 +639,7 @@
 				257A97D82017A82F00164403 /* CollectionViewDriverTests.swift in Sources */,
 				257A97C02017A5D300164403 /* TestCollectionViewModels.swift in Sources */,
 				257A97D92017A82F00164403 /* CollectionViewModelTests.swift in Sources */,
+				39D64C592A54E4DB0071A7F3 /* CollectionViewLazyDiffingTests.swift in Sources */,
 				25B1B0B920195F1C0036545F /* CollectionViewDriverDiffingTests.swift in Sources */,
 				257A97DA2017A83400164403 /* XCTest+Parameterized.swift in Sources */,
 				257A97D42017A82900164403 /* TableViewMocks.swift in Sources */,
@@ -886,7 +890,8 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = "";
-				INFOPLIST_FILE = Tests/Info.plist;
+				INFOPLIST_FILE = "$(SRCROOT)/Tests/Info.plist";
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.plangrid.ReactiveListsTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -903,7 +908,8 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = "";
-				INFOPLIST_FILE = Tests/Info.plist;
+				INFOPLIST_FILE = "$(SRCROOT)/Tests/Info.plist";
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.plangrid.ReactiveListsTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Sources/CollectionCellViewModelDataSource.swift
+++ b/Sources/CollectionCellViewModelDataSource.swift
@@ -1,0 +1,126 @@
+//
+//  PlanGrid
+//  https://www.plangrid.com
+//  https://medium.com/plangrid-technology
+//
+//  Documentation
+//  https://plangrid.github.io/ReactiveLists
+//
+//  GitHub
+//  https://github.com/plangrid/ReactiveLists
+//
+//  License
+//  Copyright © 2018-present PlanGrid, Inc.
+//  Released under an MIT license: https://opensource.org/licenses/MIT
+// 
+
+import DifferenceKit
+import Foundation
+
+/// Protocol for providing `CollectionViewModel`s to a `CollectionSectionViewModel`
+///
+/// It is itself the `Collection` of `CollectionCellViewModel` and
+/// also provides hooks for pre-fetching data
+///
+/// - Note: `[TableCellViewModel]` has a default implementation
+public protocol CollectionCellViewModelDataSourceProtocol: RandomAccessCollection where Element == CollectionCellViewModel, Index == Int {
+
+    /// Called by the equivalent `UITableViewDataSourcePrefetching` method
+    /// - Parameter indices: The indices in the section, for which to prefetch the models
+    func prefetchRowsAt<S: Sequence>(indices: S) where S.Element == Int
+
+    /// Called by the equivalent `UITableViewDataSourcePrefetching` method
+    /// - Parameter indices: The indices in the section, for which to cancel prefetchign the models
+    func cancelPrefetchingRowsAt<S: Sequence>(indices: S) where S.Element == Int
+
+    /// The `ViewRegistrationInfo` for the cells represented by this datasource
+    var cellRegistrationInfo: [ViewRegistrationInfo] { get }
+}
+
+/// The concrete data source that wraps a provided `TableCellViewModelDataSourceProtocol` implementation
+public struct CollectionCellViewModelDataSource: RandomAccessCollection {
+
+    // MARK: `CollectionCellViewModelDataSourceProtocol` wrapper blocks for type erasure
+
+    /// :nodoc:
+    private let _subscriptBlock: (Int) -> CollectionCellViewModel
+
+    /// :nodoc:
+    private let _prefetchBlock: (AnySequence<Int>) -> Void
+
+    /// :nodoc:
+    private let _prefetchCancelBlock: (AnySequence<Int>) -> Void
+
+    /// Initializes the `CollectionCellViewModelDataSource` with the provided `CollectionCellViewModelDataSourceProtocol` implementation
+    public init<DataSource: CollectionCellViewModelDataSourceProtocol>(_ dataSource: DataSource) {
+        self.init(dataSource, cellRegistrationInfo: dataSource.cellRegistrationInfo)
+    }
+
+    /// Used internally by the public init and during diffing
+    /// when cached ``ViewRegistrationInfo` is available
+    init<DataSource: CollectionCellViewModelDataSourceProtocol>(_ dataSource: DataSource, cellRegistrationInfo: [ViewRegistrationInfo]) {
+        self._prefetchBlock = dataSource.prefetchRowsAt
+        self._prefetchCancelBlock = dataSource.cancelPrefetchingRowsAt
+        self._subscriptBlock = { dataSource[$0] }
+        self.startIndex = dataSource.startIndex
+        self.endIndex = dataSource.endIndex
+        self.cellRegistrationInfo = cellRegistrationInfo
+    }
+
+    // MARK: - Protocol Implementation
+
+    /// :nodoc:
+    public let cellRegistrationInfo: [ViewRegistrationInfo]
+
+    /// :nodoc:
+    func prefetchRowsAt<S: Sequence>(indices: S) where S.Element == Int {
+        self._prefetchBlock(AnySequence(indices))
+    }
+
+    /// :nodoc:
+    func cancelPrefetchingRowsAt<S: Sequence>(indices: S) where S.Element == Int { self._prefetchCancelBlock(AnySequence(indices)) }
+
+    /// :nodoc:
+    public typealias Element = CollectionCellViewModel
+
+    /// :nodoc:
+    public typealias Index = Int
+
+    /// :nodoc:
+    public subscript(position: Int) -> CollectionCellViewModel {
+        self._subscriptBlock(position)
+    }
+
+    /// :nodoc:
+    public let startIndex: Int
+
+    /// :nodoc:
+    public let endIndex: Int
+}
+
+extension Array: CollectionCellViewModelDataSourceProtocol where Element == CollectionCellViewModel {
+
+    /// :nodoc:
+    public func prefetchRowsAt<S: Sequence>(indices: S) where S.Element == Int {}
+
+    /// :nodoc:
+    public func cancelPrefetchingRowsAt<S: Sequence>(indices: S) where S.Element == Int {}
+
+    /// :nodoc:
+    public var cellRegistrationInfo: [ViewRegistrationInfo] {
+        self.map {
+            $0.registrationInfo
+        }
+    }
+}
+
+//extension Array where Element == IndexPath {j
+//
+//    /// Helper that transforms `[IndexPath]` to sequence of pairs of sections and row sequences
+//    func indicesBySection() -> AnySequence<(Int, AnySequence<Int>)> {
+//        let indexPathsBySection = [Int: [IndexPath]](grouping: self) { $0.section }
+//        return AnySequence(indexPathsBySection.lazy.map { section, indexPaths in
+//            return (section, AnySequence(indexPaths.lazy.map { $0.row }))
+//        })
+//    }
+//}

--- a/Sources/Diffing.swift
+++ b/Sources/Diffing.swift
@@ -197,6 +197,52 @@ private final class DiffableTableCellViewModelProxy: TableCellViewModel {
     }
 }
 
+private final class DiffableCollectionCellViewModelProxy: CollectionCellViewModel {
+
+    /// Modified again to remove the placeholder diffing key. The model getter is just fetching models that already exist on a section view model, I don't see
+    /// a large efficiency issue there. The placeholder keys on invisible cells can causes issues either way, whether static or dynamic, the diff is only truly accurate
+    /// if each model in the list (visible or not) gets to supply its diffing key
+
+    /// When true, we allow diffing to access the real model's diffing key, eagerly loading it
+    private let _inVisibleBounds: Bool
+
+    /// Closure to load the model
+    private let _modelGetter: () -> CollectionCellViewModel
+
+    /// Lazy reference to the model
+    private lazy var model = self._modelGetter()
+
+    init(inVisibleBounds: Bool, modelGetter: @escaping () -> CollectionCellViewModel) {
+        self._inVisibleBounds = inVisibleBounds
+        self._modelGetter = modelGetter
+    }
+
+    /// Only accessed during display, so eager-loading is allowed here
+    var accessibilityFormat: CellAccessibilityFormat {
+        self.model.accessibilityFormat
+    }
+
+    /// Only called during display, so eager-loading is allowed here
+    func applyViewModelToCell(_ cell: UICollectionViewCell) {
+        self.model.applyViewModelToCell(cell)
+    }
+
+    /// Called before cell display
+    func willDisplay(cell: UICollectionViewCell) {
+        self.model.willDisplay(cell: cell)
+    }
+
+    /// Only accessed during display, so eager-loading is allowed here
+    var registrationInfo: ViewRegistrationInfo {
+        self.model.registrationInfo
+    }
+
+    /// Only allows accessing the real model's diffing key for visible models
+    var diffingKey: DiffingKey {
+        return self.model.diffingKey
+    }
+}
+
 /// A `DifferentiableSection` that ensures we only allow eager-loading
 /// of cells that are known to be on-screen, which avoids forcing
 /// a datasource to potentially load data that hasn't been loaded yet
@@ -290,6 +336,100 @@ struct DiffableTableSectionViewModel: Collection, DifferentiableSection {
     }
 }
 
+/// A `DifferentiableSection` that ensures we only allow eager-loading
+/// of cells that are known to be on-screen, which avoids forcing
+/// a datasource to potentially load data that hasn't been loaded yet
+/// to create new cell models (expensive)
+struct DiffableCollectionSectionViewModel: Collection, DifferentiableSection {
+
+    /// Reference to the original `CollectionSectionViewModel`
+    let _sectionModel: CollectionSectionViewModel
+
+    /// The set of indices in this section, for which we should allow
+    /// diffing to access, since these cells are visible (i.e. won't
+    /// eagerly load data that the data source may not have loaded)
+    private let _visibleIndices: Set<Int>
+
+    /// Initializes a `DiffableTableSectionViewModel` with the
+    /// section model and visibile indices in this section
+    init(sectionModel: CollectionSectionViewModel, visibleIndices: Set<Int>) {
+        self._sectionModel = sectionModel
+        self._visibleIndices = visibleIndices
+        self.startIndex = sectionModel.startIndex
+        self.endIndex = sectionModel.endIndex
+    }
+
+    // MARK: - Protocol Implementations
+
+    /// :nodoc:
+    init<C: Swift.Collection>(source: DiffableCollectionSectionViewModel, elements: C) where C.Element == AnyDiffableViewModel {
+        self._sectionModel = CollectionSectionViewModel(
+            diffingKey: source._sectionModel.diffingKey,
+            cellViewModels: [],
+            cellViewModelDataSource: CollectionCellViewModelDataSource(
+                // this will always be used for tables, and
+                // cell models have to be of type TableCellViewModel
+                //swiftlint:disable:next force_cast
+                elements.map { $0.model as! CollectionCellViewModel },
+                // pass through the already-calculated cell registration
+                // info to avoid accidental eager loading of cell models
+                cellRegistrationInfo: source._sectionModel.cellViewModelDataSource?.cellRegistrationInfo ?? []
+            ),
+            headerViewModel: source._sectionModel.headerViewModel,
+            footerViewModel: source._sectionModel.footerViewModel
+        )
+        self._visibleIndices = source._visibleIndices
+        self.startIndex = source._sectionModel.startIndex
+        self.endIndex = source._sectionModel.endIndex
+    }
+
+    /// :nodoc:
+    var diffingKey: DiffingKey { self._sectionModel.diffingKey }
+
+    /// :nodoc:
+    var differenceIdentifier: String { _sectionModel.differenceIdentifier }
+
+    /// :nodoc:
+    typealias Collection = Self
+
+    /// :nodoc:
+    typealias DifferenceIdentifier = String
+
+    /// :nodoc:
+    func isContentEqual(to source: DiffableCollectionSectionViewModel) -> Bool {
+        self._sectionModel.isContentEqual(to: source._sectionModel)
+    }
+
+    /// :nodoc:
+    var elements: DiffableCollectionSectionViewModel { self }
+
+    /// :nodoc:
+    typealias Element = AnyDiffableViewModel
+
+    /// :nodoc:
+    typealias Index = Int
+
+    /// :nodoc:
+    let startIndex: Int
+
+    /// :nodoc:
+    let endIndex: Int
+
+    /// :nodoc:
+    subscript(position: Int) -> AnyDiffableViewModel {
+        return AnyDiffableViewModel(
+            DiffableCollectionCellViewModelProxy(
+                inVisibleBounds: self._visibleIndices.contains(position)
+            ) { self._sectionModel[position] }
+        )
+    }
+
+    /// :nodoc:
+    func index(after i: Int) -> Int {
+        return self._sectionModel.index(after: i)
+    }
+}
+
 extension Array where Element == DiffableTableSectionViewModel {
 
     /// Creates a new `TableViewModel` from a `[DiffableTableSectionViewModel]`
@@ -298,6 +438,17 @@ extension Array where Element == DiffableTableSectionViewModel {
         return TableViewModel(
             sectionModels: self.map { $0._sectionModel },
             sectionIndexTitles: sectionIndexTitles
+        )
+    }
+}
+
+extension Array where Element == DiffableCollectionSectionViewModel {
+
+    /// Creates a new `CollectionViewModel` from a `[CollectionViewModel]`
+    /// for diffing
+    func makeCollectionViewModel() -> CollectionViewModel {
+        return CollectionViewModel(
+            sectionModels: self.map { $0._sectionModel }
         )
     }
 }

--- a/Sources/UICollectionView+Extensions.swift
+++ b/Sources/UICollectionView+Extensions.swift
@@ -20,7 +20,13 @@ extension UICollectionView {
 
     func registerViews(for model: CollectionViewModel) {
         model.sectionModels.forEach {
-            self.registerCellViewModels($0.cellViewModels)
+            if let dataSource = $0.cellViewModelDataSource {
+                self.registerCellViewModels(dataSource.cellRegistrationInfo.lazy.map {
+                    AnyReusableCellViewModel(registrationInfo: $0)
+                })
+            } else {
+                self.registerCellViewModels($0.cellViewModels)
+            }
 
             if let header = $0.headerViewModel {
                 self.registerSupplementaryViewModel(header)

--- a/Tests/CollectionView/CollectionViewLazyDiffingTests.swift
+++ b/Tests/CollectionView/CollectionViewLazyDiffingTests.swift
@@ -1,0 +1,101 @@
+//
+//  PlanGrid
+//  https://www.plangrid.com
+//  https://medium.com/plangrid-technology
+//
+//  Documentation
+//  https://plangrid.github.io/ReactiveLists
+//
+//  GitHub
+//  https://github.com/plangrid/ReactiveLists
+//
+//  License
+//  Copyright © 2018-present PlanGrid, Inc.
+//  Released under an MIT license: https://opensource.org/licenses/MIT
+// 
+
+@testable import ReactiveLists
+import XCTest
+
+final class CollectionViewDiffingTests: XCTestCase {
+
+    var collectionViewDataSource: CollectionViewDriver!
+    var mockCollectionView: TestCollectionView!
+
+    override func setUp() {
+        super.setUp()
+        self.mockCollectionView = TestCollectionView(
+            frame: .zero,
+            collectionViewLayout: UICollectionViewFlowLayout()
+        )
+//        self.mockCollectionView.indexPathsForVisibleRowsOverride = [
+//            IndexPath(row: 0, section: 0),
+//        ]
+        self.collectionViewDataSource = CollectionViewDriver(
+            collectionView: self.mockCollectionView,
+            shouldDeselectUponSelection: false,
+            useDataSource: true,
+            automaticDiffingEnabled: true
+        )
+    }
+
+    /// Tests that changes to individual rows result in the correct calls to update the
+    /// table view.
+    ///
+    /// - Note: We're only testing one type of row update since this is sufficient to test the
+    ///   communication between the diffing lib and the table view. The diffing lib itself has
+    ///   extensive tests for the various diffing scenarios.
+    func testChangingRows() {
+        let userCells = [LazyTestUserCell(user: "Name")]
+        let dataSource = CollectionCellViewModelDataSource(userCells)
+        let section = CollectionSectionViewModel(
+            diffingKey: "default_section",
+            cellViewModels: [],
+            cellViewModelDataSource: dataSource
+        )
+        let initialModel = CollectionViewModel(
+            sectionModels: [section]
+        )
+
+        self.collectionViewDataSource.collectionViewModel = initialModel
+
+        let testUser1 = [LazyTestUserCell(user: "TestUser1")]
+//        [LazyUserCell(user: "TestUser1"), LazyUserCell(user: "TestUser2")]
+//        let testUser2 = LazyUserCell(user: "TestUser2")
+        let dataSource1 = CollectionCellViewModelDataSource(testUser1)
+        let section2 = CollectionSectionViewModel(
+            diffingKey: "default_section",
+            cellViewModels: [],
+            cellViewModelDataSource: dataSource1
+        )
+        let updatedModel = CollectionViewModel(
+            sectionModels: [section2]
+        )
+
+        self.collectionViewDataSource.collectionViewModel = updatedModel
+
+        XCTAssertEqual(self.mockCollectionView.callsToInsertItems.count, 1)
+        XCTAssertEqual(self.mockCollectionView.callsToReloadData, 2)
+    }
+}
+
+final class LazyTestUserCell: CollectionCellViewModel, DiffableViewModel {
+    var accessibilityFormat: CellAccessibilityFormat = ""
+    let registrationInfo = ViewRegistrationInfo(classType: UICollectionViewCell.self)
+
+    let user: String
+    private(set) var diffingKeyAccessed: Bool = false
+
+    init(user: String) {
+        self.user = user
+    }
+
+    func applyViewModelToCell(_ cell: UICollectionViewCell) {}
+
+    func willDisplay(cell: UICollectionViewCell) {}
+
+    var diffingKey: String {
+        self.diffingKeyAccessed = true
+        return self.user
+    }
+}


### PR DESCRIPTION
## Changes in this pull request

Adding a CollectionCellViewModelDataSource to to make lazy-loading for CollectionView, currently we only support this for TableViews. This will allow to do pagination on Collection Views too.

[Currently a WIP]

### Checklist

- [x] All tests pass. Demo project builds and runs.
- [ ] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have reviewed the [contributing guide](https://github.com/plangrid/ReactiveLists/blob/master/.github/CONTRIBUTING.md)
