### PR TITLE
Fix row height issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The changelog for `ReactiveLists`. Also see the [releases](https://github.com/pl
 
 NEXT
 ----
+0.8.1.9
+-----
+- Added UITableViewDelegate calls for estimated row, header, footer heights
+- Changed default header/footer heights from `leastNormalMagnitude` to 0.0 
+
 0.8.1.8
 -----
 - Added support for CollectionView cells lazy-loading.

--- a/ReactiveLists.podspec
+++ b/ReactiveLists.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = "ReactiveLists"
-  s.version = "0.8.1.beta.8"
+  s.version = "0.8.1.beta.9"
 
   s.summary = "React-like API for UITableView and UICollectionView"
   s.homepage = "https://github.com/plangrid/ReactiveLists"

--- a/Sources/TableViewDriver.swift
+++ b/Sources/TableViewDriver.swift
@@ -327,6 +327,11 @@ extension TableViewDriver: UITableViewDelegate {
         guard let tableViewModel = self.tableViewModel else { return 0 }
         return tableViewModel[ifExists: indexPath]?.rowHeight ?? tableViewModel.defaultRowHeight
     }
+    /// :nodoc:
+    public func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
+        guard let tableViewModel = self.tableViewModel else { return 0 }
+        return tableViewModel[ifExists: indexPath]?.rowHeight ?? tableViewModel.defaultRowHeight
+    }
 
     /// :nodoc:
     public func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
@@ -340,12 +345,22 @@ extension TableViewDriver: UITableViewDelegate {
 
     /// :nodoc:
     public func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        return self.tableViewModel?[ifExists: section]?.headerViewModel?.height(forSection: section, totalSections: self.numberOfSections(in: tableView)) ?? CGFloat.leastNormalMagnitude
+        return self.tableViewModel?[ifExists: section]?.headerViewModel?.height(forSection: section, totalSections: self.numberOfSections(in: tableView)) ?? 0.0
+    }
+
+    /// :nodoc:
+    public func tableView(_ tableView: UITableView, estimatedHeightForHeaderInSection section: Int) -> CGFloat {
+        return self.tableViewModel?[ifExists: section]?.headerViewModel?.height(forSection: section, totalSections: self.numberOfSections(in: tableView)) ?? 0.0
     }
 
     /// :nodoc:
     public func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
-        return self.tableViewModel?[ifExists: section]?.footerViewModel?.height(forSection: section, totalSections: self.numberOfSections(in: tableView)) ?? CGFloat.leastNormalMagnitude
+        return self.tableViewModel?[ifExists: section]?.footerViewModel?.height(forSection: section, totalSections: self.numberOfSections(in: tableView)) ?? 0.0
+    }
+
+    /// :nodoc:
+    public func tableView(_ tableView: UITableView, estimatedHeightForFooterInSection section: Int) -> CGFloat {
+        return self.tableViewModel?[ifExists: section]?.footerViewModel?.height(forSection: section, totalSections: self.numberOfSections(in: tableView)) ?? 0.0
     }
 
     /// :nodoc:


### PR DESCRIPTION
## Changes in this pull request
Some jumping behavior was starting to pop up on reloads. Odd header/footer heights were causing this. Giving an estimated row height helps to fix the issue. UITableView also doesn't like that `leastNormalMagnitude` number, which also causes jumping on reload. The default value is now 0.0 for headers/footers
