### PR TITLE
return default row height instead of a calculation for estimated height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The changelog for `ReactiveLists`. Also see the [releases](https://github.com/pl
 
 NEXT
 ----
+0.8.2
+-----
+- Use default row heights for cell estimation
+
 0.8.1.9
 -----
 - Added UITableViewDelegate calls for estimated row, header, footer heights

--- a/ReactiveLists.podspec
+++ b/ReactiveLists.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = "ReactiveLists"
-  s.version = "0.8.1.beta.9"
+  s.version = "0.8.2"
 
   s.summary = "React-like API for UITableView and UICollectionView"
   s.homepage = "https://github.com/plangrid/ReactiveLists"

--- a/Sources/TableViewDriver.swift
+++ b/Sources/TableViewDriver.swift
@@ -330,7 +330,7 @@ extension TableViewDriver: UITableViewDelegate {
     /// :nodoc:
     public func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
         guard let tableViewModel = self.tableViewModel else { return 0 }
-        return tableViewModel[ifExists: indexPath]?.rowHeight ?? tableViewModel.defaultRowHeight
+        return tableViewModel.defaultRowHeight
     }
 
     /// :nodoc:


### PR DESCRIPTION
## Changes in this pull request
Made cell row heights static.  This was causing performance issues on large table views (1 million + cells)

### Checklist

- [ x ] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [ x ] I have reviewed the [contributing guide](https://github.com/plangrid/ReactiveLists/blob/master/.github/CONTRIBUTING.md)
