### PR TITLE
feat(TableViewDriver): allow lightweightDiffing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The changelog for `ReactiveLists`. Also see the [releases](https://github.com/pl
 
 NEXT
 ----
+0.8.3
+-----
+- Added `lightweightDiffing` option to `TableViewDriver`
+
+----
 0.8.2
 -----
 - Use default row heights for cell estimation

--- a/ReactiveLists.podspec
+++ b/ReactiveLists.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = "ReactiveLists"
-  s.version = "0.8.2"
+  s.version = "0.8.3"
 
   s.summary = "React-like API for UITableView and UICollectionView"
   s.homepage = "https://github.com/plangrid/ReactiveLists"


### PR DESCRIPTION
## Changes in this pull request
* add optional `lightweightDiffing` option for use with very large but largely static lists
Issue fixed: #

For forms we found that performance is massively better with automatic diffing disabled for large forms. Unfortunately, doing a full reload of tableview data causes text fields to resign focus which is a bad experience for end users.
Lightweight diffing is an option I'd like to explore for forms since we don't frequently add/remove/move sections/cells.

### Checklist

- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have reviewed the [contributing guide](https://github.com/plangrid/ReactiveLists/blob/master/.github/CONTRIBUTING.md)
