### PR TITLE
Fix ambiguous contains (Xcode 16.3)

### DIFF
--- a/Sources/CollectionViewDriver.swift
+++ b/Sources/CollectionViewDriver.swift
@@ -260,8 +260,7 @@ extension CollectionViewDriver: UICollectionViewDataSourcePrefetching {
         guard let sectionModels = self.collectionViewModel?.sectionModels else { return }
         // if this is called during a batch update, sections can shift
         // around, which can lead to accessing a bad section
-        let indexIsValid = sectionModels.indices.contains
-        for (section, indices) in indexPaths.indicesBySection() where indexIsValid(section) {
+        for (section, indices) in indexPaths.indicesBySection() where sectionModels.indices.contains(section) {
             guard let dataSource = sectionModels[section].cellViewModelDataSource else { return }
             enumerationBlock(dataSource, indices)
         }

--- a/Sources/TableViewDriver.swift
+++ b/Sources/TableViewDriver.swift
@@ -318,8 +318,7 @@ extension TableViewDriver: UITableViewDataSourcePrefetching {
         guard let sectionModels = self.tableViewModel?.sectionModels else { return }
         // if this is called during a batch update, sections can shift
         // around, which can lead to accessing a bad section
-        let indexIsValid = sectionModels.indices.contains
-        for (section, indices) in indexPaths.indicesBySection() where indexIsValid(section) {
+        for (section, indices) in indexPaths.indicesBySection() where sectionModels.indices.contains(section) {
             enumerationBlock(sectionModels[section].cellViewModelDataSource, indices)
         }
     }


### PR DESCRIPTION
## Changes in this pull request
This PR resolves an ambiguity issue with the contains function when building with Xcode 16.3. The Swift compiler introduced stricter type checking, which caused ambiguous behavior in some contexts. The fix involves explicitly specifying the element type in the contains call to ensure clarity and compatibility with the updated compiler.